### PR TITLE
Reload on hash change

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,11 @@ async function start(): Promise<void> {
     // Given an IDiceRoller, we can render the value and provide controls for users to roll it.
     const div = document.getElementById("content") as HTMLDivElement;
     renderDiceRoller(diceRoller, div);
+
+    // Reload the page on any further hash changes, e.g. in case you want to paste in a different document ID.
+    window.addEventListener("hashchange", () => {
+        location.reload();
+    });
 }
 
 start().catch((error) => console.error(error));


### PR DESCRIPTION
REPRO:
1. Have 2 windows open side-by-side with the example running
2. Navigate one window to localhost:8080 to create a new document
3. Copy the URL (with the new docId) and paste it in the other window

EXPECTATION
Both windows are collaborating on the same, new document

ACTUAL
Second window is still on the old document, because the hash change doesn't trigger a reload

PROPOSED FIX
This change forces a reload when the hash changes after rendering.