### PR TITLE
Update Fluid versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,43 +16,41 @@
       }
     },
     "@fluidframework/agent-scheduler": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.25.1-833.tgz",
-      "integrity": "sha1-A9/xOeA2UehncC27g9QPG/lTQ9g=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/agent-scheduler/-/agent-scheduler-0.25.1-1809.tgz",
+      "integrity": "sha1-NTfz6Y1HGJmaoGUX+riN8NBym6w=",
       "requires": {
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
-        "@fluidframework/map": "^0.25.1-833",
-        "@fluidframework/register-collection": "^0.25.1-833",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore": "^0.25.1-1809",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
+        "@fluidframework/map": "^0.25.1-1809",
+        "@fluidframework/register-collection": "^0.25.1-1809",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
         "debug": "^4.1.1",
         "uuid": "^3.3.2"
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.25.1-833.tgz",
-      "integrity": "sha1-/LK4h2xtt2OfhPGr2GSB19M2hgQ=",
+      "version": "0.25.1-1641",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/aqueduct/-/aqueduct-0.25.1-1641.tgz",
+      "integrity": "sha1-a86l8AaMFJayCP5VYW47h07oTDY=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
         "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/container-loader": "^0.25.1-833",
-        "@fluidframework/container-runtime": "^0.25.1-833",
-        "@fluidframework/container-runtime-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
-        "@fluidframework/framework-interfaces": "^0.25.1-833",
-        "@fluidframework/map": "^0.25.1-833",
-        "@fluidframework/request-handler": "^0.25.1-833",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
-        "@fluidframework/runtime-utils": "^0.25.1-833",
-        "@fluidframework/synthesize": "^0.25.1-833",
-        "@fluidframework/view-adapters": "^0.25.1-833",
-        "@fluidframework/view-interfaces": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1641",
+        "@fluidframework/container-loader": "^0.25.1-1641",
+        "@fluidframework/container-runtime": "^0.25.1-1641",
+        "@fluidframework/container-runtime-definitions": "^0.25.1-1641",
+        "@fluidframework/core-interfaces": "^0.25.1-1641",
+        "@fluidframework/datastore": "^0.25.1-1641",
+        "@fluidframework/datastore-definitions": "^0.25.1-1641",
+        "@fluidframework/map": "^0.25.1-1641",
+        "@fluidframework/request-handler": "^0.25.1-1641",
+        "@fluidframework/runtime-definitions": "^0.25.1-1641",
+        "@fluidframework/runtime-utils": "^0.25.1-1641",
+        "@fluidframework/synthesize": "^0.25.1-1641",
+        "@fluidframework/view-interfaces": "^0.25.1-1641",
         "uuid": "^3.3.2"
       }
     },
@@ -77,58 +75,74 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.25.1-833.tgz",
-      "integrity": "sha1-ml0OCSZiH81TEDBAKJPD0xha9X4=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-definitions/-/container-definitions-0.25.1-1809.tgz",
+      "integrity": "sha1-cO4MOhqTNa0O1BUHRjBX0PRwOsc=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0"
       }
     },
     "@fluidframework/container-loader": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.25.1-833.tgz",
-      "integrity": "sha1-LjNr3hqSR4W1WRHeVJO4SBXBk30=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-loader/-/container-loader-0.25.1-1809.tgz",
+      "integrity": "sha1-crPQ4gyHV5iK9Iql12V9JozUvjE=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/container-utils": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
-        "@fluidframework/driver-utils": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/container-utils": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-utils": "^0.25.1-1809",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/telemetry-utils": "^0.25.1-833",
+        "@fluidframework/telemetry-utils": "^0.25.1-1809",
         "@types/double-ended-queue": "^2.1.0",
         "debug": "^4.1.1",
         "double-ended-queue": "^2.1.0-0",
         "lodash": "^4.17.19",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.25.1-833.tgz",
-      "integrity": "sha1-IjwYymN5UwaqZl/CQAtkQCj2Gas=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime/-/container-runtime-0.25.1-1809.tgz",
+      "integrity": "sha1-vFoWjrdpVMjB3ZgrrxHD//fa3As=",
       "requires": {
-        "@fluidframework/agent-scheduler": "^0.25.1-833",
+        "@fluidframework/agent-scheduler": "^0.25.1-1809",
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/container-runtime-definitions": "^0.25.1-833",
-        "@fluidframework/container-utils": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
-        "@fluidframework/driver-utils": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/container-runtime-definitions": "^0.25.1-1809",
+        "@fluidframework/container-utils": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-utils": "^0.25.1-1809",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
-        "@fluidframework/runtime-utils": "^0.25.1-833",
-        "@fluidframework/telemetry-utils": "^0.25.1-833",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
+        "@fluidframework/runtime-utils": "^0.25.1-1809",
+        "@fluidframework/telemetry-utils": "^0.25.1-1809",
         "@types/debug": "^4.1.5",
         "@types/double-ended-queue": "^2.1.0",
         "@types/node": "^10.17.24",
@@ -136,221 +150,311 @@
         "debug": "^4.1.1",
         "double-ended-queue": "^2.1.0-0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.25.1-833.tgz",
-      "integrity": "sha1-72fArWXy6Os02ddASeuU7mNUgc8=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.25.1-1809.tgz",
+      "integrity": "sha1-EIdH4mLKkLkseu4WWSrMbhHAd5c=",
       "requires": {
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
         "@types/node": "^10.17.24"
       }
     },
     "@fluidframework/container-utils": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-utils/-/container-utils-0.25.1-833.tgz",
-      "integrity": "sha1-Cz+0+NmPjHNfsfw2b5eFcm31L8A=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/container-utils/-/container-utils-0.25.1-1809.tgz",
+      "integrity": "sha1-MfRYAlfZgVOqZIKiCymzIeR5sDM=",
       "requires": {
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/telemetry-utils": "^0.25.1-833"
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/telemetry-utils": "^0.25.1-1809"
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/core-interfaces/-/core-interfaces-0.25.1-833.tgz",
-      "integrity": "sha1-xTRC6KjCbTaRAjhfgT5kTDzgZpk="
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/core-interfaces/-/core-interfaces-0.25.1-1809.tgz",
+      "integrity": "sha1-V0vuHBYpsrVmi56zSH4ucF3zmD8="
     },
     "@fluidframework/datastore": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/datastore/-/datastore-0.25.1-833.tgz",
-      "integrity": "sha1-VcxqS1s+HZU1E63qaMuszex0tdM=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/datastore/-/datastore-0.25.1-1809.tgz",
+      "integrity": "sha1-k5sOmysp2zjyf6REOOGhXXSWjXs=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/container-utils": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
-        "@fluidframework/driver-utils": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/container-utils": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-utils": "^0.25.1-1809",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
-        "@fluidframework/runtime-utils": "^0.25.1-833",
-        "@fluidframework/telemetry-utils": "^0.25.1-833",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
+        "@fluidframework/runtime-utils": "^0.25.1-1809",
+        "@fluidframework/telemetry-utils": "^0.25.1-1809",
         "assert": "^2.0.0",
         "debug": "^4.1.1",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/datastore-definitions/-/datastore-definitions-0.25.1-833.tgz",
-      "integrity": "sha1-bYs0hOaGblp1CCl7vl5kOAwptCU=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/datastore-definitions/-/datastore-definitions-0.25.1-1809.tgz",
+      "integrity": "sha1-jrNLYJQNPnyv5qbCjmiMlkZWpiY=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
         "@types/node": "^10.17.24"
       }
     },
     "@fluidframework/driver-base": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.25.1-833.tgz",
-      "integrity": "sha1-K/a1g2CoxEu6OnubKx84RKT8crg=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-base/-/driver-base-0.25.1-1809.tgz",
+      "integrity": "sha1-XT9MBxZb07Obfa6tK6Qz+QFVO9w=",
       "requires": {
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
-        "@fluidframework/driver-utils": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-utils": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
         "@types/debug": "^4.1.5",
         "@types/node": "^10.17.24",
         "@types/socket.io-client": "^1.4.32",
         "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.25.1-833.tgz",
-      "integrity": "sha1-E+LBbMvj5fv5SjwFzD2S8vHEKEc=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-definitions/-/driver-definitions-0.25.1-1809.tgz",
+      "integrity": "sha1-QXX3dH3QNiUUcsKkzyCnsCuPCsQ=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "buffer": "^5.6.0"
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/protocol-definitions": "^0.1011.1-0"
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.25.1-833.tgz",
-      "integrity": "sha1-f/n+MN8moGwQhe8xzYLJ2fEVfW0=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/driver-utils/-/driver-utils-0.25.1-1809.tgz",
+      "integrity": "sha1-w9zjpw6LownMYhlGfpq2eUZrXok=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
         "@fluidframework/gitresources": "^0.1011.1-0",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/telemetry-utils": "^0.25.1-833"
-      }
-    },
-    "@fluidframework/framework-interfaces": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/framework-interfaces/-/framework-interfaces-0.25.1-833.tgz",
-      "integrity": "sha1-ByP2ru6Ctwuih4QKd+dxRW0V9Oc=",
-      "requires": {
-        "@fluidframework/core-interfaces": "^0.25.1-833"
+        "@fluidframework/telemetry-utils": "^0.25.1-1809"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/get-tinylicious-container": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/get-tinylicious-container/-/get-tinylicious-container-0.25.1-833.tgz",
-      "integrity": "sha1-t7niBgXVbDH0UotFT7r2/fKijTc=",
+      "version": "0.25.1-1641",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/get-tinylicious-container/-/get-tinylicious-container-0.25.1-1641.tgz",
+      "integrity": "sha1-PnZUO9iOpCAjkAmhW/VKkO82wNY=",
       "requires": {
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/container-loader": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1641",
+        "@fluidframework/container-loader": "^0.25.1-1641",
+        "@fluidframework/core-interfaces": "^0.25.1-1641",
+        "@fluidframework/driver-definitions": "^0.25.1-1641",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/routerlicious-driver": "^0.25.1-833",
+        "@fluidframework/routerlicious-driver": "^0.25.1-1641",
         "jsonwebtoken": "^8.4.0",
         "uuid": "^3.3.2"
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1011.1-821",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1011.1-821.tgz",
-      "integrity": "sha1-CvFM0SK+P9kvLQ9wG4FjqiuyyrU="
+      "version": "0.1011.1-1810",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/gitresources/-/gitresources-0.1011.1-1810.tgz",
+      "integrity": "sha1-4Q96zLO0eJDliGKWt93SCeelgEg="
     },
     "@fluidframework/map": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.25.1-833.tgz",
-      "integrity": "sha1-W1VAA+VMZIrbajfFGrPihxI+L+A=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/map/-/map-0.25.1-1809.tgz",
+      "integrity": "sha1-KsSOBqZPTHNhAVlzxSR/Xx2ta7Y=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/shared-object-base": "^0.25.1-833",
+        "@fluidframework/shared-object-base": "^0.25.1-1809",
         "debug": "^4.1.1"
-      }
-    },
-    "@fluidframework/protocol-base": {
-      "version": "0.1011.1-821",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1011.1-821.tgz",
-      "integrity": "sha1-JLsPbcndN/P5MF7cF6JKO6sgWpY=",
-      "requires": {
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/gitresources": "^0.1011.1-821",
-        "@fluidframework/protocol-definitions": "^0.1011.1-821",
-        "assert": "^2.0.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@fluidframework/protocol-definitions": {
-      "version": "0.1011.1-821",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1011.1-821.tgz",
-      "integrity": "sha1-iqb7kAffAkhehpioyDOKcDkbHe4=",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.18.1",
-        "buffer": "^4.3.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "4.9.2",
-          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/buffer/-/buffer-4.9.2.tgz",
-          "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4",
-            "isarray": "^1.0.0"
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
           }
         }
       }
     },
-    "@fluidframework/register-collection": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.25.1-833.tgz",
-      "integrity": "sha1-HTAnYX8CY68gie8RNZc4iHxccsw=",
+    "@fluidframework/protocol-base": {
+      "version": "0.1011.1-1810",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-base/-/protocol-base-0.1011.1-1810.tgz",
+      "integrity": "sha1-+K6dYWHd46/YWeNirwKZDrvWXPM=",
       "requires": {
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/gitresources": "^0.1011.1-1810",
+        "@fluidframework/protocol-definitions": "^0.1011.1-1810",
+        "assert": "^2.0.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
+      }
+    },
+    "@fluidframework/protocol-definitions": {
+      "version": "0.1011.1-1810",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/protocol-definitions/-/protocol-definitions-0.1011.1-1810.tgz",
+      "integrity": "sha1-fjY4pqs2ExFXkUrhQ/ZK2Pii7rY=",
+      "requires": {
+        "@fluidframework/common-definitions": "^0.18.1"
+      }
+    },
+    "@fluidframework/register-collection": {
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/register-collection/-/register-collection-0.25.1-1809.tgz",
+      "integrity": "sha1-CPgLX6ts0AWfmbl1RumL1EjWpm4=",
+      "requires": {
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/shared-object-base": "^0.25.1-833",
+        "@fluidframework/shared-object-base": "^0.25.1-1809",
         "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/request-handler": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.25.1-833.tgz",
-      "integrity": "sha1-GtW/fMFl0MJ4yEqSJ/BezcNZ+34=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/request-handler/-/request-handler-0.25.1-1809.tgz",
+      "integrity": "sha1-KASL1SvpjkEo50w6ER+KJhyusa8=",
       "requires": {
-        "@fluidframework/container-runtime-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/runtime-definitions": "^0.25.1-833",
-        "@fluidframework/runtime-utils": "^0.25.1-833"
+        "@fluidframework/container-runtime-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/runtime-definitions": "^0.25.1-1809",
+        "@fluidframework/runtime-utils": "^0.25.1-1809"
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.25.1-833.tgz",
-      "integrity": "sha1-6fQ/4W5tZLtykH9XZJX2eRfx9aI=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.25.1-1809.tgz",
+      "integrity": "sha1-55/a0L5RDzQ1I1gHhQ+HaUP7pR8=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/driver-base": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
-        "@fluidframework/driver-utils": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/driver-base": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
+        "@fluidframework/driver-utils": "^0.25.1-1809",
         "@fluidframework/gitresources": "^0.1011.1-0",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
@@ -361,50 +465,98 @@
         "jwt-decode": "^2.2.0",
         "socket.io-client": "^2.1.1",
         "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.25.1-833.tgz",
-      "integrity": "sha1-do9FPg13luFkeHEoN3Bs4U3EBXY=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-definitions/-/runtime-definitions-0.25.1-1809.tgz",
+      "integrity": "sha1-TnY6bJRMgt+aIhiad1bm+bXcqLM=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/driver-definitions": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/driver-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
         "@types/node": "^10.17.24"
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.25.1-833.tgz",
-      "integrity": "sha1-ZvaMyoSy2dfwrP/4uzAM8mBJC7k=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/runtime-utils/-/runtime-utils-0.25.1-1809.tgz",
+      "integrity": "sha1-iLnbAFgrU4lP8a7RKol07po2F2w=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-base": "^0.1011.1-0",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/runtime-definitions": "^0.25.1-833"
+        "@fluidframework/runtime-definitions": "^0.25.1-1809"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-client": {
-      "version": "0.1011.1-821",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-client/-/server-services-client-0.1011.1-821.tgz",
-      "integrity": "sha1-Kqgp2RD+kRZW6KyAvZowbOINkx8=",
+      "version": "0.1011.1-1810",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/server-services-client/-/server-services-client-0.1011.1-1810.tgz",
+      "integrity": "sha1-aZ0qGa9tTZ5TPGTUWFBzYaSBJPc=",
       "requires": {
-        "@fluidframework/common-utils": "^0.21.0",
-        "@fluidframework/gitresources": "^0.1011.1-821",
-        "@fluidframework/protocol-base": "^0.1011.1-821",
-        "@fluidframework/protocol-definitions": "^0.1011.1-821",
+        "@fluidframework/common-utils": "^0.22.1-0",
+        "@fluidframework/gitresources": "^0.1011.1-1810",
+        "@fluidframework/protocol-base": "^0.1011.1-1810",
+        "@fluidframework/protocol-definitions": "^0.1011.1-1810",
         "@types/node": "^10.17.24",
         "axios": "^0.18.0",
         "debug": "^4.1.1",
         "jsonwebtoken": "^8.4.0",
         "sillyname": "0.1.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/server-services-shared": {
@@ -542,17 +694,17 @@
       }
     },
     "@fluidframework/shared-object-base": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.25.1-833.tgz",
-      "integrity": "sha1-QtiLPzKJKNQc7sC/Jq3/LneZk/A=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/shared-object-base/-/shared-object-base-0.25.1-1809.tgz",
+      "integrity": "sha1-sl9RNhnhVbOgCwEkaxXVsQJSw/Q=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/container-definitions": "^0.25.1-833",
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/datastore": "^0.25.1-833",
-        "@fluidframework/datastore-definitions": "^0.25.1-833",
+        "@fluidframework/container-definitions": "^0.25.1-1809",
+        "@fluidframework/core-interfaces": "^0.25.1-1809",
+        "@fluidframework/datastore": "^0.25.1-1809",
+        "@fluidframework/datastore-definitions": "^0.25.1-1809",
         "@fluidframework/protocol-definitions": "^0.1011.1-0",
-        "@fluidframework/telemetry-utils": "^0.25.1-833",
+        "@fluidframework/telemetry-utils": "^0.25.1-1809",
         "@types/debug": "^4.1.5",
         "@types/node": "^10.17.24",
         "debug": "^4.1.1",
@@ -560,41 +712,46 @@
       }
     },
     "@fluidframework/synthesize": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.25.1-833.tgz",
-      "integrity": "sha1-quie7yGkmM+r5zP2eGQzF8ZSf28=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/synthesize/-/synthesize-0.25.1-1809.tgz",
+      "integrity": "sha1-M11gFEEt2Xrd9QT7Vp+MMWaM7+Q=",
       "requires": {
-        "@fluidframework/core-interfaces": "^0.25.1-833"
+        "@fluidframework/core-interfaces": "^0.25.1-1809"
       }
     },
     "@fluidframework/telemetry-utils": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/telemetry-utils/-/telemetry-utils-0.25.1-833.tgz",
-      "integrity": "sha1-R7Otg7Qmr4jdIGkPoPpMiIXwuCM=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/telemetry-utils/-/telemetry-utils-0.25.1-1809.tgz",
+      "integrity": "sha1-1rKF81Gtpn/6Ljx34Sug/XqzqcM=",
       "requires": {
         "@fluidframework/common-definitions": "^0.18.1",
-        "@fluidframework/common-utils": "^0.21.0",
+        "@fluidframework/common-utils": "^0.22.1-0",
         "debug": "^4.1.1",
         "events": "^3.1.0"
-      }
-    },
-    "@fluidframework/view-adapters": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-adapters/-/view-adapters-0.25.1-833.tgz",
-      "integrity": "sha1-B1K+gIj9UxZo5V7bswI/mhs/KaE=",
-      "requires": {
-        "@fluidframework/core-interfaces": "^0.25.1-833",
-        "@fluidframework/view-interfaces": "^0.25.1-833",
-        "react": "^16.10.2",
-        "react-dom": "^16.10.2"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "0.22.1",
+          "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/common-utils/-/common-utils-0.22.1.tgz",
+          "integrity": "sha1-nTpywFvqyRmSjoyF5MG8tASog54=",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.18.1",
+            "assert": "^2.0.0",
+            "base64-js": "^1.3.1",
+            "events": "^3.1.0",
+            "lodash": "^4.17.19",
+            "performance-now": "^2.1.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "0.25.1-833",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.25.1-833.tgz",
-      "integrity": "sha1-oQF7gEaFvbIehFu4x0uwHHkO9/E=",
+      "version": "0.25.1-1809",
+      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/@fluidframework/view-interfaces/-/view-interfaces-0.25.1-1809.tgz",
+      "integrity": "sha1-+RZT94kn2ngmUtzKV+usegYrpRM=",
       "requires": {
-        "@fluidframework/core-interfaces": "^0.25.1-833"
+        "@fluidframework/core-interfaces": "^0.25.1-1809"
       }
     },
     "@sentry/apm": {
@@ -4865,7 +5022,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -4914,11 +5072,6 @@
       "version": "4.0.1",
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha1-Vf1M1sXmSR523BJZON2GP1zU8tw="
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -5321,14 +5474,6 @@
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/looper/-/looper-2.0.0.tgz",
       "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew=",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lower-case": {
       "version": "2.0.1",
@@ -5958,7 +6103,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
@@ -6424,16 +6570,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.6",
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -6623,32 +6759,6 @@
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
-    },
-    "react": {
-      "version": "16.13.1",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/react/-/react-16.13.1.tgz",
-      "integrity": "sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha1-wb03MxoEhsB47lTEdAcgmTsuDn8=",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ="
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -6871,15 +6981,6 @@
       "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
-    },
-    "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://offnet.pkgs.visualstudio.com/officenet/_packaging/fluid/npm/registry/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha1-Tz4u0sGn1laB9MhU+oxaHMtA8ZY=",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "schema-utils": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
   "license": "MIT",
   "author": "Microsoft",
   "scripts": {
-    "build": "webpack --env.prod",
+    "build": "webpack --env.prod --env.clean",
+    "build:dev": "webpack --env.clean",
     "start": "concurrently \"npm:start:server\" \"npm:start:client\"",
     "start:client": "webpack-dev-server --open",
     "start:server": "tinylicious"
   },
   "dependencies": {
-    "@fluidframework/aqueduct": "0.25.1-833",
-    "@fluidframework/get-tinylicious-container": "0.25.1-833"
+    "@fluidframework/aqueduct": "0.25.1-1641",
+    "@fluidframework/get-tinylicious-container": "0.25.1-1641"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = env => {
     const htmlTemplate = "./src/index.html";
-    const plugins = env && env.prod
+    const plugins = env && env.clean
         ? [new CleanWebpackPlugin(), new HtmlWebpackPlugin({ template: htmlTemplate })]
         : [new HtmlWebpackPlugin({ template: htmlTemplate })];
 


### PR DESCRIPTION
This pulls in the update to Aqueduct to drop the React dependency.

Also a small update to webpack config and scripts to facilitate build of dev.