### PR TITLE
add issues redirect

### DIFF
--- a/.github/ISSUES_TEMPLATE/config.yml
+++ b/.github/ISSUES_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://stackoverflow.com/questions/tagged/fluid-framework
+    about: Please ask and answer usage questions on Stack Overflow.
+  - name: Issue
+    url: https://github.com/microsoft/FluidFramework/issues
+    about: Please file an issue in the Fluid Framework repo.


### PR DESCRIPTION
We don't want to manage issues in this repo but we do want developers to be able to open issue against the helloworld tutorial.

This will direct developers to stackoverflow for questions and the FluidFramework repo for issues.