### PR TITLE
adding note on dice representation on different browsers (

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm start
 
 This will open a browser window to the example.  You can navigate to the same URL in a second window to see changes propagating between clients.
 
+**NOTE**: Since the dice are represented by ASCII, they may appear differently depending on your browser.
+
 To webpack the bundle and output the result in `./dist`, you can run:
 
 ```bash


### PR DESCRIPTION
Fixes microsoft/FluidFramework#4592

I have added a note on different representations of dice in different browsers.
