### PR TITLE
Fix the mismatch name in document comment

### DIFF
--- a/src/view/vueView.ts
+++ b/src/view/vueView.ts
@@ -7,7 +7,7 @@ import { createApp } from 'vue';
 import { IRenderView } from "../types";
 /**
  * Render Dice into a given HTMLElement as a text character, with a button to roll it.
- * @param dataObject - The Data Object to be rendered
+ * @param data - The Data Object to be rendered
  * @param div - The HTMLElement to render into
  */
 export const  vueRenderView: IRenderView = (data, div) => {


### PR DESCRIPTION
The parameter name in the source code is `data`, but the document comment used `dataObject`. This PR will fix this mismatch.