### PR TITLE
Version changed from 0.43 to 0.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,88 +25,453 @@
             }
         },
         "@fluid-experimental/fluid-framework": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-framework/-/fluid-framework-0.43.0.tgz",
-            "integrity": "sha512-Vzk5YNYft+r6BQobZljxUYHK8Uuq+swAkZMhJPw8VluvOCj59qnLozJdflgM5+a1kXw/KDmv1Uo+9x6HEWP1vw==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-framework/-/fluid-framework-0.45.4.tgz",
+            "integrity": "sha512-n2GTGMqO+HhO23dxxTUYZELC+o6UxgpyGvZK9qLCR+2kOHmSoWM2s50WgisGdz8SBpSALucTRhYV8363ZYEdOw==",
             "requires": {
-                "@fluid-experimental/fluid-static": "^0.43.0",
-                "@fluidframework/aqueduct": "^0.43.0",
-                "@fluidframework/map": "^0.43.0",
-                "@fluidframework/merge-tree": "^0.43.0",
-                "@fluidframework/sequence": "^0.43.0"
+                "@fluid-experimental/fluid-static": "^0.45.4",
+                "@fluidframework/aqueduct": "^0.45.4",
+                "@fluidframework/map": "^0.45.4",
+                "@fluidframework/merge-tree": "^0.45.4",
+                "@fluidframework/sequence": "^0.45.4"
             }
         },
         "@fluid-experimental/fluid-static": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-static/-/fluid-static-0.43.0.tgz",
-            "integrity": "sha512-qWDRcw+eSVWydbb7micixUcqEJHA3sp0DLsCxj4QGk/4smeMIqMTIlR8P7Z0k2c36+ccHaPg/d5Y8I8EkmNTXQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-static/-/fluid-static-0.45.4.tgz",
+            "integrity": "sha512-9jtZHg+R7tjCj9pP/ygrAlI72TLmundhA0HjKogolPxyNwTQswzN+Piabt0d41AU9jD79OE2zVxaXJl8TFmw2Q==",
             "requires": {
-                "@fluidframework/aqueduct": "^0.43.0",
+                "@fluidframework/aqueduct": "^0.45.4",
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-loader": "^0.43.0",
-                "@fluidframework/container-runtime-definitions": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-loader": "^0.45.4",
+                "@fluidframework/container-runtime-definitions": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/request-handler": "^0.43.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0"
+                "@fluidframework/request-handler": "^0.45.4",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 }
             }
         },
         "@fluid-experimental/frs-client": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluid-experimental/frs-client/-/frs-client-0.43.0.tgz",
-            "integrity": "sha512-H9sn+p1HtFCpWxc2lwuZgA2ajNsYlviHWTxNRebpIrWkMq2iLy3MSdcTzFFYyKDD+33PfzUvnTnpdSKhXcwCHg==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluid-experimental/frs-client/-/frs-client-0.45.4.tgz",
+            "integrity": "sha512-Tk/7mgN1hZuVEkPDvjndxcf90F8Fy1j8q8+ZrnZbtNSqZ0UQN4DDtcTkd+zS7pJlGCaqUzyJRIrvmukOCjOz8w==",
             "requires": {
-                "@fluid-experimental/fluid-framework": "^0.43.0",
+                "@fluid-experimental/fluid-framework": "^0.45.4",
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/container-loader": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/driver-definitions": "^0.39.0",
+                "@fluidframework/container-loader": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/driver-definitions": "^0.39.6",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/routerlicious-driver": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/server-services-client": "^0.1027.0",
-                "@fluidframework/test-runtime-utils": "^0.43.0",
+                "@fluidframework/routerlicious-driver": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/server-services-client": "^0.1028.1",
+                "@fluidframework/test-runtime-utils": "^0.45.4",
+                "axios": "^0.21.1",
                 "debug": "^4.1.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-                },
-                "@fluidframework/server-services-client": {
-                    "version": "0.1027.0",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1027.0.tgz",
-                    "integrity": "sha512-FQcC3TPhfs/GHtfW/0aqGD5rehwhgCmZcmAWDi+QkKatWzV/Z/SD0uyA7Bk9qRE5jgNNP3ny5XaZ4jETJJ2Zvg==",
+                "@fluid-experimental/fluid-framework": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-framework/-/fluid-framework-0.45.4.tgz",
+                    "integrity": "sha512-n2GTGMqO+HhO23dxxTUYZELC+o6UxgpyGvZK9qLCR+2kOHmSoWM2s50WgisGdz8SBpSALucTRhYV8363ZYEdOw==",
                     "requires": {
-                        "@fluidframework/common-utils": "^0.31.0",
-                        "@fluidframework/gitresources": "^0.1027.0",
-                        "@fluidframework/protocol-base": "^0.1027.0",
+                        "@fluid-experimental/fluid-static": "^0.45.4",
+                        "@fluidframework/aqueduct": "^0.45.4",
+                        "@fluidframework/map": "^0.45.4",
+                        "@fluidframework/merge-tree": "^0.45.4",
+                        "@fluidframework/sequence": "^0.45.4"
+                    }
+                },
+                "@fluid-experimental/fluid-static": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-static/-/fluid-static-0.45.4.tgz",
+                    "integrity": "sha512-9jtZHg+R7tjCj9pP/ygrAlI72TLmundhA0HjKogolPxyNwTQswzN+Piabt0d41AU9jD79OE2zVxaXJl8TFmw2Q==",
+                    "requires": {
+                        "@fluidframework/aqueduct": "^0.45.4",
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-loader": "^0.45.4",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
                         "@fluidframework/protocol-definitions": "^0.1024.0",
-                        "@types/node": "^12.19.0",
-                        "axios": "^0.21.1",
-                        "debug": "^4.1.1",
-                        "jsrsasign": "^10.2.0",
-                        "jwt-decode": "^3.0.0",
-                        "sillyname": "0.1.0",
+                        "@fluidframework/request-handler": "^0.45.4",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4"
+                    }
+                },
+                "@fluidframework/aqueduct": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.45.4.tgz",
+                    "integrity": "sha512-AoCwF2vnIGV8FkoJiAh8coKMW9Amtu7P/bQZ2TLNnu6nTyUxc2rpu1fdYKMjwu9AimG5mTm0Drs/nyAo03zyuA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-loader": "^0.45.4",
+                        "@fluidframework/container-runtime": "^0.45.4",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore": "^0.45.4",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/map": "^0.45.4",
+                        "@fluidframework/request-handler": "^0.45.4",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4",
+                        "@fluidframework/synthesize": "^0.45.4",
+                        "@fluidframework/view-interfaces": "^0.45.4",
                         "uuid": "^8.3.1"
                     }
                 },
+                "@fluidframework/common-utils": {
+                    "version": "0.32.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+                    "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@types/events": "^3.0.0",
+                        "base64-js": "^1.5.1",
+                        "events": "^3.1.0",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.4.11"
+                    }
+                },
+                "@fluidframework/container-definitions": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.8.tgz",
+                    "integrity": "sha512-ayXuC2BT+4EhCTq3Wij3V8fSI5E/m4NOUz9F6HgN1dGI1lo7OFDGUw33iKs5HMA+LiOjRj9R9JmnqOL/xnfZfA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.0",
+                        "@fluidframework/core-interfaces": "^0.39.8",
+                        "@fluidframework/driver-definitions": "^0.39.8",
+                        "@fluidframework/protocol-definitions": "^0.1024.0"
+                    },
+                    "dependencies": {
+                        "@fluidframework/driver-definitions": {
+                            "version": "0.39.8",
+                            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.8.tgz",
+                            "integrity": "sha512-nEWtbdVneq7IUPqWC22DeG6n3v57NDjHuHBQkpA9vbrHkhkTgXbFNK7vLhev1XHUjWLbAkBskcABsXAwNQCvJw==",
+                            "requires": {
+                                "@fluidframework/common-definitions": "^0.20.0",
+                                "@fluidframework/core-interfaces": "^0.39.8",
+                                "@fluidframework/protocol-definitions": "^0.1024.0"
+                            }
+                        }
+                    }
+                },
+                "@fluidframework/container-loader": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.45.4.tgz",
+                    "integrity": "sha512-6bxn0egJWEHrR8WpulOFZDb6zwdFB5Qm3QzlbnE+67DkIMYjoTfUToaXBAaj6k1V+yCUdiTk6dnHvcwE6FColA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-utils": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/driver-utils": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "abort-controller": "^3.0.0",
+                        "debug": "^4.1.1",
+                        "double-ended-queue": "^2.1.0-0",
+                        "lodash": "^4.17.21",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/container-runtime": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.45.4.tgz",
+                    "integrity": "sha512-OYe8ub6f0pV7hkx3o3tX9zUIkmwGuFshnDbJHktRuZz7YMW5NsFrVktMY9X4rnGM/WPeIG8o9nvwi4A6Y7OKvA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/container-utils": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore": "^0.45.4",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/driver-utils": "^0.45.4",
+                        "@fluidframework/garbage-collector": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "debug": "^4.1.1",
+                        "double-ended-queue": "^2.1.0-0",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/container-runtime-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.45.4.tgz",
+                    "integrity": "sha512-DtCH9EmYTwnxH0hOqcUj4md6Clso8JYQza9yaxqsgd91QEyBNyeOnTwb7LBLx1Xv0puIJwWrdgibGyZ0zuTpjA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/container-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.45.4.tgz",
+                    "integrity": "sha512-TVCTceXDqJwyUza25HjtXOTyjKm0wmHIgDodKZFHRUqmwmmuBUj+s/1lwJc1wPZyZFdlHkBaJ0Xt/mey1D1dVg==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4"
+                    }
+                },
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "@fluidframework/datastore": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.45.4.tgz",
+                    "integrity": "sha512-UjoxzSJk4WoMHD4ERlzochQttHYNxKHj17sFY+EiI8geBQh73ABrX9bp9YEHiLRCXr1orBwiwodfxiIXoBsqqw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-utils": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/driver-utils": "^0.45.4",
+                        "@fluidframework/garbage-collector": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "debug": "^4.1.1",
+                        "lodash": "^4.17.21",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/datastore-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.45.4.tgz",
+                    "integrity": "sha512-1PDX1sImYrOITDm+cJaSBgCi0UJjfi+MpzfMsMvkevEj5aUQ5n0A/yTQbRT2UUaqh3v1ZpcZ2886U0LoVLnVtw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/driver-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.45.4.tgz",
+                    "integrity": "sha512-cOAFXZwZ1gxzIradrIVAmiZ3Ob0GokgHEfXhmm8GzlFkzRi9GbUh871XJqFzycQszVkYQGH5ea4KdcsM3YcBTQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/garbage-collector": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.45.4.tgz",
+                    "integrity": "sha512-s88DGJ5OPOv/2cWAw5IiC90D3RRxvZUfs9gvnp6XJQrLSTRIZnwtaOPnU4iFKuvBVwPwEcwLN3lbatKl5fJ5+A==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/runtime-definitions": "^0.45.4"
+                    }
+                },
+                "@fluidframework/gitresources": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+                    "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+                },
+                "@fluidframework/map": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.45.4.tgz",
+                    "integrity": "sha512-eG6lT0av0BsPEze7elr0rxrhiztsZ02zStcxU6OXSTCl5ZwNjB6VrjSNwYcQRRNvK217Xi08/QuUEer/7bKeKQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/driver-utils": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/shared-object-base": "^0.45.4",
+                        "debug": "^4.1.1",
+                        "path-browserify": "^1.0.1"
+                    }
+                },
+                "@fluidframework/merge-tree": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.45.4.tgz",
+                    "integrity": "sha512-mVTDT0zFdCpx0Bb+hhW6MLpQMRwIBUqdR9n1PscLcZeBLF0QbdiLS/hoeUxsdigA5NdIaXw77KRpg089S6lgXg==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4"
+                    }
+                },
+                "@fluidframework/protocol-base": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+                    "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "lodash": "^4.17.21"
+                    }
+                },
+                "@fluidframework/request-handler": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.45.4.tgz",
+                    "integrity": "sha512-V9kgYAQGr1reLf6eSGjD7INzO16QqiWciNTXMQZJfje+o3xUkTgaPop5xzB1L1N3TygGTZiAG458UZhi/fR1og==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4"
+                    }
+                },
+                "@fluidframework/runtime-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.45.4.tgz",
+                    "integrity": "sha512-zcruHY8KdSJswr0P+PsTJXPo5xGvQQO8e21ud/6DfFh7JHDTxlwP8VW+YfE7qwwPNqUFjhchg6hR1xqNIdTktw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/runtime-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.45.4.tgz",
+                    "integrity": "sha512-sCktjBuwY1ZtNiqoGtVs/mYB8WkcQg3MoJqAViEVbf0GPGu1hAgHwsntALeWjgHL+SxBqmYu4TvynSxU4mAtlg==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/garbage-collector": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4"
+                    }
+                },
+                "@fluidframework/sequence": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.45.4.tgz",
+                    "integrity": "sha512-ZofaBIVKuKmqM/TSYpYrxLx67anxju1EtgNKvER44eBNXmf8NKv7mS69Nnq4lgRWsdYmb5MqXCgWxmiQlK+DmQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/merge-tree": "^0.45.4",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4",
+                        "@fluidframework/shared-object-base": "^0.45.4",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "debug": "^4.1.1",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/shared-object-base": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.45.4.tgz",
+                    "integrity": "sha512-WpDSxFqQfRpWHSvSVGGI5hQJzsVDF/EJe+cJSNf6nm0fpO0UyIQ9eMuwk4Mhfl7yFDhSuVEX0iL8L3tbuepmew==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore": "^0.45.4",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@fluidframework/runtime-utils": "^0.45.4",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "debug": "^4.1.1",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/synthesize": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.45.4.tgz",
+                    "integrity": "sha512-y1zN3BAA9NvDvINKj6kuk6nnAQRxxfPld0UIhUqFswmXAIBSXHx5GZHwvSH4QS/rCnrmm4sDbK0nCv5y9MyRsA==",
+                    "requires": {
+                        "@fluidframework/core-interfaces": "^0.39.7"
+                    }
+                },
+                "@fluidframework/telemetry-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.45.4.tgz",
+                    "integrity": "sha512-+CFqR2hnged4MnB9zp30rWWuDZa41wNe5uCbcZ6SqHMOfAT/aSKnKdy++kYyiz2yAzVr0by9IXCYJy9H0sEN5w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "debug": "^4.1.1",
+                        "events": "^3.1.0"
+                    }
+                },
+                "@fluidframework/view-interfaces": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.45.4.tgz",
+                    "integrity": "sha512-rsDAjwX0GvGHboUgwKMI32X0/DZ24uaUZSjeqyN7CG24jz7wghPxDFxjL8OqXfX4JboiYwRQmV59oKw0w0pVqw==",
+                    "requires": {
+                        "@fluidframework/core-interfaces": "^0.39.7"
+                    }
+                },
                 "@types/node": {
-                    "version": "12.20.16",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-                    "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -116,32 +481,32 @@
             }
         },
         "@fluidframework/aqueduct": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.43.0.tgz",
-            "integrity": "sha512-awQrAd2eKDi6TX6XettHbVL11FLorol8MY0hjMg+JSMPg79K9Bxt4dia2gplPh12feIP381OsS1CuKCLmY9MqQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.45.4.tgz",
+            "integrity": "sha512-AoCwF2vnIGV8FkoJiAh8coKMW9Amtu7P/bQZ2TLNnu6nTyUxc2rpu1fdYKMjwu9AimG5mTm0Drs/nyAo03zyuA==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-loader": "^0.43.0",
-                "@fluidframework/container-runtime": "^0.43.0",
-                "@fluidframework/container-runtime-definitions": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore": "^0.43.0",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/map": "^0.43.0",
-                "@fluidframework/request-handler": "^0.43.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/synthesize": "^0.43.0",
-                "@fluidframework/view-interfaces": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-loader": "^0.45.4",
+                "@fluidframework/container-runtime": "^0.45.4",
+                "@fluidframework/container-runtime-definitions": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore": "^0.45.4",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/map": "^0.45.4",
+                "@fluidframework/request-handler": "^0.45.4",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/synthesize": "^0.45.4",
+                "@fluidframework/view-interfaces": "^0.45.4",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -150,59 +515,67 @@
                 }
             }
         },
+        "@fluidframework/common-definitions": {
+            "version": "0.20.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
+            "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+        },
         "@fluidframework/common-utils": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.31.0.tgz",
-            "integrity": "sha512-gZFD5tY7pD1ktDlXIfLI1WKD36/3zJzSQx/bbsldHxODSE7p/cUinDC+0Nj+CMy3sy0XajUJ849ZHsUZmBUYVA==",
+            "version": "0.32.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+            "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
                 "@types/events": "^3.0.0",
-                "base64-js": "^1.3.1",
+                "base64-js": "^1.5.1",
                 "events": "^3.1.0",
                 "lodash": "^4.17.21",
                 "sha.js": "^2.4.11"
-            },
-            "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-                }
             }
         },
         "@fluidframework/container-definitions": {
-            "version": "0.39.6",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.6.tgz",
-            "integrity": "sha512-toyJItu+W8IkEGYh5UXZ0CC7V30NCbKBXgBPL2Rwvf31dZ6TA91KM3nmutL/bCXHTHzH4jDkyaLqi2UQMx4UCg==",
+            "version": "0.39.8",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.8.tgz",
+            "integrity": "sha512-ayXuC2BT+4EhCTq3Wij3V8fSI5E/m4NOUz9F6HgN1dGI1lo7OFDGUw33iKs5HMA+LiOjRj9R9JmnqOL/xnfZfA==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.0",
-                "@fluidframework/core-interfaces": "^0.39.6",
-                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/core-interfaces": "^0.39.8",
+                "@fluidframework/driver-definitions": "^0.39.8",
                 "@fluidframework/protocol-definitions": "^0.1024.0"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "@fluidframework/driver-definitions": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.8.tgz",
+                    "integrity": "sha512-nEWtbdVneq7IUPqWC22DeG6n3v57NDjHuHBQkpA9vbrHkhkTgXbFNK7vLhev1XHUjWLbAkBskcABsXAwNQCvJw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.0",
+                        "@fluidframework/core-interfaces": "^0.39.8",
+                        "@fluidframework/protocol-definitions": "^0.1024.0"
+                    }
                 }
             }
         },
         "@fluidframework/container-loader": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.43.0.tgz",
-            "integrity": "sha512-qU1/vLyAVjmbp431/NqmmEkYxCn24UlhT1hv3kTcncAngjYc29fmKppE4kdQASk/bng9p5gS02Y+tc89zn6BjQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.45.4.tgz",
+            "integrity": "sha512-6bxn0egJWEHrR8WpulOFZDb6zwdFB5Qm3QzlbnE+67DkIMYjoTfUToaXBAaj6k1V+yCUdiTk6dnHvcwE6FColA==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-utils": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-utils": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "abort-controller": "^3.0.0",
                 "debug": "^4.1.1",
                 "double-ended-queue": "^2.1.0-0",
@@ -210,10 +583,10 @@
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -223,34 +596,34 @@
             }
         },
         "@fluidframework/container-runtime": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.43.0.tgz",
-            "integrity": "sha512-vpyjl78WclBWqdw+uiQXQYDmcjNF64SNaW4MVQPuxGNPqx6X2Y67oIi3etw7NHLPF5PaXoVfK20t4V445NjriA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.45.4.tgz",
+            "integrity": "sha512-OYe8ub6f0pV7hkx3o3tX9zUIkmwGuFshnDbJHktRuZz7YMW5NsFrVktMY9X4rnGM/WPeIG8o9nvwi4A6Y7OKvA==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-runtime-definitions": "^0.43.0",
-                "@fluidframework/container-utils": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore": "^0.43.0",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
-                "@fluidframework/garbage-collector": "^0.43.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-runtime-definitions": "^0.45.4",
+                "@fluidframework/container-utils": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore": "^0.45.4",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
+                "@fluidframework/garbage-collector": "^0.45.4",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "debug": "^4.1.1",
                 "double-ended-queue": "^2.1.0-0",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -260,48 +633,41 @@
             }
         },
         "@fluidframework/container-runtime-definitions": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.43.0.tgz",
-            "integrity": "sha512-9dxLP2oKZuHpD5bXTLmH+H2q73PrXFQaP2TZUlQpFfR4EYI0vTY8QmLHn4odSfLnk/kDm/Yngqd4ieJpXJ9Wmw==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.45.4.tgz",
+            "integrity": "sha512-DtCH9EmYTwnxH0hOqcUj4md6Clso8JYQza9yaxqsgd91QEyBNyeOnTwb7LBLx1Xv0puIJwWrdgibGyZ0zuTpjA==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/driver-definitions": "^0.39.0",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/driver-definitions": "^0.39.6",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
                 "@types/node": "^12.19.0"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "@types/node": {
-                    "version": "12.20.16",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-                    "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 }
             }
         },
         "@fluidframework/container-utils": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.43.0.tgz",
-            "integrity": "sha512-dvx0aTj+jcDnQKQVVrkmuO/OoG3a9xtD3lhZDcA3QXxctyrqAoqFlwfzXcLcNTRPEZPu9Z3sepdxTtNYO65pwA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.45.4.tgz",
+            "integrity": "sha512-TVCTceXDqJwyUza25HjtXOTyjKm0wmHIgDodKZFHRUqmwmmuBUj+s/1lwJc1wPZyZFdlHkBaJ0Xt/mey1D1dVg==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/telemetry-utils": "^0.43.0"
-            },
-            "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-                }
+                "@fluidframework/telemetry-utils": "^0.45.4"
             }
         },
         "@fluidframework/core-interfaces": {
@@ -310,33 +676,33 @@
             "integrity": "sha512-0xjYiRrd71+vS/cXPO8ejPuEfju7TD1NQquA+nWUcB9J5vv5NzdgQAcFAiPSmm/gwpKj4qbuVcN3144GN+qNEg=="
         },
         "@fluidframework/datastore": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.43.0.tgz",
-            "integrity": "sha512-MIRu9Jxu9J5BJQmggVxuMLeKbhrnQewcr1eYALo8lMvSNO/fwxetHjTBiL91sY0sUDaW2AB6BMtQfuFB6nWr9w==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.45.4.tgz",
+            "integrity": "sha512-UjoxzSJk4WoMHD4ERlzochQttHYNxKHj17sFY+EiI8geBQh73ABrX9bp9YEHiLRCXr1orBwiwodfxiIXoBsqqw==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-utils": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
-                "@fluidframework/garbage-collector": "^0.43.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-utils": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
+                "@fluidframework/garbage-collector": "^0.45.4",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "debug": "^4.1.1",
                 "lodash": "^4.17.21",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -346,48 +712,110 @@
             }
         },
         "@fluidframework/datastore-definitions": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.43.0.tgz",
-            "integrity": "sha512-ShAg0at75qJV2z5d5D4Qi7KHUVM4u2LP2Mp691puL5KVMgQFn3dyGX0n5JO2Xd6ciIIgii1oey57rS/KKN/nbQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.45.4.tgz",
+            "integrity": "sha512-1PDX1sImYrOITDm+cJaSBgCi0UJjfi+MpzfMsMvkevEj5aUQ5n0A/yTQbRT2UUaqh3v1ZpcZ2886U0LoVLnVtw==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
                 "@types/node": "^12.19.0"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "@types/node": {
-                    "version": "12.20.16",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-                    "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 }
             }
         },
         "@fluidframework/driver-base": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.43.0.tgz",
-            "integrity": "sha512-7ayZPYoir4/T5mpYPgMxjeIqlzhzJmYT9ksiu9I1jdw68tuEWJ6s5vqyZKi8eci5DLmwHki1QDpcwxWxdscm9g==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.45.4.tgz",
+            "integrity": "sha512-hRKfFRxwakmtj5+Dn3EKY0Un/rCjCsxrmMDa1jTEKZMCXPlNYswPU6PbtlPTkcV6MZwQ8wwmH0QWUc1IDAKpsw==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "debug": "^4.1.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/common-utils": {
+                    "version": "0.32.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+                    "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@types/events": "^3.0.0",
+                        "base64-js": "^1.5.1",
+                        "events": "^3.1.0",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.4.11"
+                    }
+                },
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "@fluidframework/driver-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.45.4.tgz",
+                    "integrity": "sha512-cOAFXZwZ1gxzIradrIVAmiZ3Ob0GokgHEfXhmm8GzlFkzRi9GbUh871XJqFzycQszVkYQGH5ea4KdcsM3YcBTQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/gitresources": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+                    "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+                },
+                "@fluidframework/protocol-base": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+                    "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "lodash": "^4.17.21"
+                    }
+                },
+                "@fluidframework/telemetry-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.45.4.tgz",
+                    "integrity": "sha512-+CFqR2hnged4MnB9zp30rWWuDZa41wNe5uCbcZ6SqHMOfAT/aSKnKdy++kYyiz2yAzVr0by9IXCYJy9H0sEN5w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "debug": "^4.1.1",
+                        "events": "^3.1.0"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
@@ -409,25 +837,25 @@
             }
         },
         "@fluidframework/driver-utils": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.43.0.tgz",
-            "integrity": "sha512-bHJ9BXDSrgEcOI2m7FtN3tbwRUzQkEUdY0MysvnbuHn0fHYqAg7MIFjCALyXRJx6nMhUa39Esf4F1INNT5mEsQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.45.4.tgz",
+            "integrity": "sha512-cOAFXZwZ1gxzIradrIVAmiZ3Ob0GokgHEfXhmm8GzlFkzRi9GbUh871XJqFzycQszVkYQGH5ea4KdcsM3YcBTQ==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/gitresources": "^0.1027.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/gitresources": "^0.1028.1",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -437,81 +865,73 @@
             }
         },
         "@fluidframework/garbage-collector": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.43.0.tgz",
-            "integrity": "sha512-ACytvxe8MTG/ZWwifYLccn+7fnk1L7OOKro8LX/N9ZF+tsUf0SeWsPHTEp5Q0DhEhYZQLqCSNX17sqS4WGyaXQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.45.4.tgz",
+            "integrity": "sha512-s88DGJ5OPOv/2cWAw5IiC90D3RRxvZUfs9gvnp6XJQrLSTRIZnwtaOPnU4iFKuvBVwPwEcwLN3lbatKl5fJ5+A==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/runtime-definitions": "^0.43.0"
-            },
-            "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-                }
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/runtime-definitions": "^0.45.4"
             }
         },
         "@fluidframework/gitresources": {
-            "version": "0.1027.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1027.0.tgz",
-            "integrity": "sha512-nFgew2ojQIgmhX5rP532VOC0hex3ffAk2eOcl5Eo4CBMqWutjyVem2hpcdnCGa54jDI/cVyOsvLrCvBhDX0WEw=="
+            "version": "0.1028.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+            "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
         },
         "@fluidframework/map": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.43.0.tgz",
-            "integrity": "sha512-CQXDPMiT3JgbUpcS1T8zmfPR20+5I4oJA6YqlOEfdFQPY/S5dn9XBQGJRI9wHZNprMu5gkLhMAkE+PaCXcJUpQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.45.4.tgz",
+            "integrity": "sha512-eG6lT0av0BsPEze7elr0rxrhiztsZ02zStcxU6OXSTCl5ZwNjB6VrjSNwYcQRRNvK217Xi08/QuUEer/7bKeKQ==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/driver-utils": "^0.43.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/driver-utils": "^0.45.4",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/shared-object-base": "^0.43.0",
+                "@fluidframework/shared-object-base": "^0.45.4",
                 "debug": "^4.1.1",
                 "path-browserify": "^1.0.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 }
             }
         },
         "@fluidframework/merge-tree": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.43.0.tgz",
-            "integrity": "sha512-oTj8XyCfT2UCaEqESvu+2dLwVIeK7TBhs2PxdbC+XRbBWaqclw0P5H9xM3neDUZ55D7X+eeUq/HGcDIJwkZdvA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.45.4.tgz",
+            "integrity": "sha512-mVTDT0zFdCpx0Bb+hhW6MLpQMRwIBUqdR9n1PscLcZeBLF0QbdiLS/hoeUxsdigA5NdIaXw77KRpg089S6lgXg==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/telemetry-utils": "^0.43.0"
+                "@fluidframework/telemetry-utils": "^0.45.4"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 }
             }
         },
         "@fluidframework/protocol-base": {
-            "version": "0.1027.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1027.0.tgz",
-            "integrity": "sha512-JZGHpGL9+PZn9L6z+wUdiS9z0PcR/vusd1Tz6Ei5FN/6U4WdInpFtlcBcjGq0tjYzOym1ouipNu8HPPCxTI9IA==",
+            "version": "0.1028.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+            "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
             "requires": {
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/gitresources": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/gitresources": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "assert": "^2.0.0",
                 "lodash": "^4.17.21"
             }
         },
@@ -531,66 +951,106 @@
             }
         },
         "@fluidframework/request-handler": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.43.0.tgz",
-            "integrity": "sha512-8qz1KGokTSX/baqB5cAD46WAvV5zRuOZ1I6f6gjPtrN/z6gPtRr+O5pGoq4JBYpVDZJGEf8hxw3oalC7OrZWzA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.45.4.tgz",
+            "integrity": "sha512-V9kgYAQGr1reLf6eSGjD7INzO16QqiWciNTXMQZJfje+o3xUkTgaPop5xzB1L1N3TygGTZiAG458UZhi/fR1og==",
             "requires": {
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-runtime-definitions": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0"
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-runtime-definitions": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4"
+            },
+            "dependencies": {
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                }
             }
         },
         "@fluidframework/routerlicious-driver": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.43.0.tgz",
-            "integrity": "sha512-9Fd/+yC4IvQlFn8R4+T6kQBql1U1DTWj74CiEahaP+kP9t7ZbCkGRPn9ltW7VYelqNVMQ1xvOAHCU9WQSUdXbQ==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.45.4.tgz",
+            "integrity": "sha512-/y9Zc5fv0lzUHXGFMsR5IWYTbbhc4Jt8KMHX99ZyVRmsXrGGKDG7Rir8jH9XE69Qy606kh/gr4gGrJbjRr4fcQ==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/driver-base": "^0.43.0",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
-                "@fluidframework/gitresources": "^0.1027.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/driver-base": "^0.45.4",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
+                "@fluidframework/gitresources": "^0.1028.1",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/server-services-client": "^0.1027.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/server-services-client": "^0.1028.1",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "axios": "^0.21.1",
                 "debug": "^4.1.1",
                 "json-stringify-safe": "5.0.1",
-                "socket.io-client": "^2.1.1",
+                "socket.io-client": "^2.4.0",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
-                },
-                "@fluidframework/server-services-client": {
-                    "version": "0.1027.0",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1027.0.tgz",
-                    "integrity": "sha512-FQcC3TPhfs/GHtfW/0aqGD5rehwhgCmZcmAWDi+QkKatWzV/Z/SD0uyA7Bk9qRE5jgNNP3ny5XaZ4jETJJ2Zvg==",
+                "@fluidframework/common-utils": {
+                    "version": "0.32.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+                    "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
                     "requires": {
-                        "@fluidframework/common-utils": "^0.31.0",
-                        "@fluidframework/gitresources": "^0.1027.0",
-                        "@fluidframework/protocol-base": "^0.1027.0",
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@types/events": "^3.0.0",
+                        "base64-js": "^1.5.1",
+                        "events": "^3.1.0",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.4.11"
+                    }
+                },
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "@fluidframework/driver-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.45.4.tgz",
+                    "integrity": "sha512-cOAFXZwZ1gxzIradrIVAmiZ3Ob0GokgHEfXhmm8GzlFkzRi9GbUh871XJqFzycQszVkYQGH5ea4KdcsM3YcBTQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-base": "^0.1028.1",
                         "@fluidframework/protocol-definitions": "^0.1024.0",
-                        "@types/node": "^12.19.0",
-                        "axios": "^0.21.1",
-                        "debug": "^4.1.1",
-                        "jsrsasign": "^10.2.0",
-                        "jwt-decode": "^3.0.0",
-                        "sillyname": "0.1.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
                         "uuid": "^8.3.1"
                     }
                 },
-                "@types/node": {
-                    "version": "12.20.16",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-                    "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+                "@fluidframework/gitresources": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+                    "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+                },
+                "@fluidframework/protocol-base": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+                    "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "lodash": "^4.17.21"
+                    }
+                },
+                "@fluidframework/telemetry-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.45.4.tgz",
+                    "integrity": "sha512-+CFqR2hnged4MnB9zp30rWWuDZa41wNe5uCbcZ6SqHMOfAT/aSKnKdy++kYyiz2yAzVr0by9IXCYJy9H0sEN5w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "debug": "^4.1.1",
+                        "events": "^3.1.0"
+                    }
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -600,78 +1060,137 @@
             }
         },
         "@fluidframework/runtime-definitions": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.43.0.tgz",
-            "integrity": "sha512-XQ2xDqgquv79wlNNBpwEYh8+BMbiRYEOmdZRvJNmcvHaewCv6vciuu5qo8LI0O0KzJgYEWM8QOWMOOjCVPWbfg==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.45.4.tgz",
+            "integrity": "sha512-zcruHY8KdSJswr0P+PsTJXPo5xGvQQO8e21ud/6DfFh7JHDTxlwP8VW+YfE7qwwPNqUFjhchg6hR1xqNIdTktw==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/driver-definitions": "^0.39.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/driver-definitions": "^0.39.6",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
                 "@types/node": "^12.19.0"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "@types/node": {
-                    "version": "12.20.16",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-                    "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA=="
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 }
             }
         },
         "@fluidframework/runtime-utils": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.43.0.tgz",
-            "integrity": "sha512-WEjH66gynHNJtzT7CsWdvfZTKOabynZyFJ0MlAvNfy1xTpiO4qNsOK2JWhchljH5xGI82O8mPggzpKLaRHN0eA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.45.4.tgz",
+            "integrity": "sha512-sCktjBuwY1ZtNiqoGtVs/mYB8WkcQg3MoJqAViEVbf0GPGu1hAgHwsntALeWjgHL+SxBqmYu4TvynSxU4mAtlg==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/container-runtime-definitions": "^0.43.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/garbage-collector": "^0.43.0",
-                "@fluidframework/protocol-base": "^0.1027.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/container-runtime-definitions": "^0.45.4",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/garbage-collector": "^0.45.4",
+                "@fluidframework/protocol-base": "^0.1028.1",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0"
+                "@fluidframework/runtime-definitions": "^0.45.4"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 }
             }
         },
         "@fluidframework/sequence": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.43.0.tgz",
-            "integrity": "sha512-PznNGDJhOr/++oZrgPPw1Dba3LPkPXJcrrC0MNJbbfwGdm3vm+aR6lvGj1XBNBvzFw50BLfwX1mQQ5q9XPevKw==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.45.4.tgz",
+            "integrity": "sha512-ZofaBIVKuKmqM/TSYpYrxLx67anxju1EtgNKvER44eBNXmf8NKv7mS69Nnq4lgRWsdYmb5MqXCgWxmiQlK+DmQ==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/merge-tree": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/merge-tree": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/shared-object-base": "^0.43.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/shared-object-base": "^0.45.4",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "debug": "^4.1.1",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
+            }
+        },
+        "@fluidframework/server-services-client": {
+            "version": "0.1028.1",
+            "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1028.1.tgz",
+            "integrity": "sha512-6oWGf/RmyUG1eKt9A/3v8e7XjARS8S07SmDIjkwhb03IR4poGtQHuqqE7eUnP9CVs3GBlfwQ8BdEglfe7GOYnw==",
+            "requires": {
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/gitresources": "^0.1028.1",
+                "@fluidframework/protocol-base": "^0.1028.1",
+                "@fluidframework/protocol-definitions": "^0.1024.0",
+                "@types/node": "^12.19.0",
+                "axios": "^0.21.1",
+                "debug": "^4.1.1",
+                "jsrsasign": "^10.2.0",
+                "jwt-decode": "^3.0.0",
+                "sillyname": "0.1.0",
+                "uuid": "^8.3.1"
+            },
+            "dependencies": {
+                "@fluidframework/common-utils": {
+                    "version": "0.32.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+                    "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@types/events": "^3.0.0",
+                        "base64-js": "^1.5.1",
+                        "events": "^3.1.0",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.4.11"
+                    }
+                },
+                "@fluidframework/gitresources": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+                    "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+                },
+                "@fluidframework/protocol-base": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+                    "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "lodash": "^4.17.21"
+                    }
+                },
+                "@types/node": {
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -681,28 +1200,28 @@
             }
         },
         "@fluidframework/shared-object-base": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.43.0.tgz",
-            "integrity": "sha512-jpHatxVCXEjXQqTwmfSrGOEbfVXuyG/8WDsmm+SRYjHA91KBXMn12cfQGZY48JiNCeYG9P+KPRO5e8HvwTJfAA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.45.4.tgz",
+            "integrity": "sha512-WpDSxFqQfRpWHSvSVGGI5hQJzsVDF/EJe+cJSNf6nm0fpO0UyIQ9eMuwk4Mhfl7yFDhSuVEX0iL8L3tbuepmew==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore": "^0.43.0",
-                "@fluidframework/datastore-definitions": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore": "^0.45.4",
+                "@fluidframework/datastore-definitions": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "debug": "^4.1.1",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -712,57 +1231,210 @@
             }
         },
         "@fluidframework/synthesize": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.43.0.tgz",
-            "integrity": "sha512-814J7OhGfjWOJrvhyrMIo25/jZj7LOuVkdkGucwFuhJwLNtBQGx7DF+rrLfzomLFuo2QKq4MAORUa2XH04DmBA==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.45.4.tgz",
+            "integrity": "sha512-y1zN3BAA9NvDvINKj6kuk6nnAQRxxfPld0UIhUqFswmXAIBSXHx5GZHwvSH4QS/rCnrmm4sDbK0nCv5y9MyRsA==",
             "requires": {
-                "@fluidframework/core-interfaces": "^0.39.5"
-            }
-        },
-        "@fluidframework/telemetry-utils": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.43.0.tgz",
-            "integrity": "sha512-LODZgc1HRxCJnHHjaTm69p0AJjgc4ly4gM/ON6H+OIXDmnWlALkVXkvl7qdCJKtTHPPuF7y5+q+R/msh1oHkbg==",
-            "requires": {
-                "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "debug": "^4.1.1",
-                "events": "^3.1.0"
+                "@fluidframework/core-interfaces": "^0.39.7"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
                 }
             }
         },
-        "@fluidframework/test-runtime-utils": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.43.0.tgz",
-            "integrity": "sha512-haMpQxrEt0/k5rEA+jZ5z29Y6oHzY4anAOZIoNQbF+pM8/3O76+vTuAKFoc5vyjWtS5BnT2QwBfxpkRW6B8jVA==",
+        "@fluidframework/telemetry-utils": {
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.45.4.tgz",
+            "integrity": "sha512-+CFqR2hnged4MnB9zp30rWWuDZa41wNe5uCbcZ6SqHMOfAT/aSKnKdy++kYyiz2yAzVr0by9IXCYJy9H0sEN5w==",
             "requires": {
                 "@fluidframework/common-definitions": "^0.20.1",
-                "@fluidframework/common-utils": "^0.31.0",
-                "@fluidframework/container-definitions": "^0.39.5",
-                "@fluidframework/core-interfaces": "^0.39.5",
-                "@fluidframework/datastore-definitions": "^0.43.0",
-                "@fluidframework/driver-definitions": "^0.39.0",
-                "@fluidframework/driver-utils": "^0.43.0",
+                "@fluidframework/common-utils": "^0.32.1",
+                "debug": "^4.1.1",
+                "events": "^3.1.0"
+            }
+        },
+        "@fluidframework/test-runtime-utils": {
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.45.4.tgz",
+            "integrity": "sha512-R4d9/oTrPRCdGsq1i/lCXvfUYqqUuxyHwiGBu4sQCF+BYwkynApNXuyN1JiiG6Hbv77W0TX+iPHK72F6jIkzGw==",
+            "requires": {
+                "@fluidframework/common-definitions": "^0.20.1",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/container-definitions": "^0.39.8",
+                "@fluidframework/core-interfaces": "^0.39.7",
+                "@fluidframework/datastore-definitions": "^0.45.4",
+                "@fluidframework/driver-definitions": "^0.39.6",
+                "@fluidframework/driver-utils": "^0.45.4",
                 "@fluidframework/protocol-definitions": "^0.1024.0",
-                "@fluidframework/routerlicious-driver": "^0.43.0",
-                "@fluidframework/runtime-definitions": "^0.43.0",
-                "@fluidframework/runtime-utils": "^0.43.0",
-                "@fluidframework/telemetry-utils": "^0.43.0",
+                "@fluidframework/routerlicious-driver": "^0.45.4",
+                "@fluidframework/runtime-definitions": "^0.45.4",
+                "@fluidframework/runtime-utils": "^0.45.4",
+                "@fluidframework/telemetry-utils": "^0.45.4",
                 "axios": "^0.21.1",
                 "jsrsasign": "^10.2.0",
                 "uuid": "^8.3.1"
             },
             "dependencies": {
-                "@fluidframework/common-definitions": {
-                    "version": "0.20.1",
-                    "resolved": "https://registry.npmjs.org/@fluidframework/common-definitions/-/common-definitions-0.20.1.tgz",
-                    "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
+                "@fluidframework/common-utils": {
+                    "version": "0.32.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
+                    "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@types/events": "^3.0.0",
+                        "base64-js": "^1.5.1",
+                        "events": "^3.1.0",
+                        "lodash": "^4.17.21",
+                        "sha.js": "^2.4.11"
+                    }
+                },
+                "@fluidframework/container-definitions": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.8.tgz",
+                    "integrity": "sha512-ayXuC2BT+4EhCTq3Wij3V8fSI5E/m4NOUz9F6HgN1dGI1lo7OFDGUw33iKs5HMA+LiOjRj9R9JmnqOL/xnfZfA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.0",
+                        "@fluidframework/core-interfaces": "^0.39.8",
+                        "@fluidframework/driver-definitions": "^0.39.8",
+                        "@fluidframework/protocol-definitions": "^0.1024.0"
+                    },
+                    "dependencies": {
+                        "@fluidframework/driver-definitions": {
+                            "version": "0.39.8",
+                            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.8.tgz",
+                            "integrity": "sha512-nEWtbdVneq7IUPqWC22DeG6n3v57NDjHuHBQkpA9vbrHkhkTgXbFNK7vLhev1XHUjWLbAkBskcABsXAwNQCvJw==",
+                            "requires": {
+                                "@fluidframework/common-definitions": "^0.20.0",
+                                "@fluidframework/core-interfaces": "^0.39.8",
+                                "@fluidframework/protocol-definitions": "^0.1024.0"
+                            }
+                        }
+                    }
+                },
+                "@fluidframework/container-runtime-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.45.4.tgz",
+                    "integrity": "sha512-DtCH9EmYTwnxH0hOqcUj4md6Clso8JYQza9yaxqsgd91QEyBNyeOnTwb7LBLx1Xv0puIJwWrdgibGyZ0zuTpjA==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                },
+                "@fluidframework/datastore-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.45.4.tgz",
+                    "integrity": "sha512-1PDX1sImYrOITDm+cJaSBgCi0UJjfi+MpzfMsMvkevEj5aUQ5n0A/yTQbRT2UUaqh3v1ZpcZ2886U0LoVLnVtw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/driver-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.45.4.tgz",
+                    "integrity": "sha512-cOAFXZwZ1gxzIradrIVAmiZ3Ob0GokgHEfXhmm8GzlFkzRi9GbUh871XJqFzycQszVkYQGH5ea4KdcsM3YcBTQ==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/telemetry-utils": "^0.45.4",
+                        "uuid": "^8.3.1"
+                    }
+                },
+                "@fluidframework/garbage-collector": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.45.4.tgz",
+                    "integrity": "sha512-s88DGJ5OPOv/2cWAw5IiC90D3RRxvZUfs9gvnp6XJQrLSTRIZnwtaOPnU4iFKuvBVwPwEcwLN3lbatKl5fJ5+A==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/runtime-definitions": "^0.45.4"
+                    }
+                },
+                "@fluidframework/gitresources": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1028.1.tgz",
+                    "integrity": "sha512-8jr//Jt0PKsD+8O46LMWT0yxO4eYv2zkdm4n2FY8hLYIjskFwCi9ZS/+vueYcIkJXBIYy8yTPTx9Mvn8z0Re9Q=="
+                },
+                "@fluidframework/protocol-base": {
+                    "version": "0.1028.1",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1028.1.tgz",
+                    "integrity": "sha512-R8YSJpsQ8UWbKh+HQtfiA2uW9ogb3MANztcYVkCinNzxRIX8nRTHvLHKTVBnKqj/L3SvE38WbqmbQ24J/CwuqQ==",
+                    "requires": {
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/gitresources": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "lodash": "^4.17.21"
+                    }
+                },
+                "@fluidframework/runtime-definitions": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.45.4.tgz",
+                    "integrity": "sha512-zcruHY8KdSJswr0P+PsTJXPo5xGvQQO8e21ud/6DfFh7JHDTxlwP8VW+YfE7qwwPNqUFjhchg6hR1xqNIdTktw==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/driver-definitions": "^0.39.6",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@types/node": "^12.19.0"
+                    }
+                },
+                "@fluidframework/runtime-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.45.4.tgz",
+                    "integrity": "sha512-sCktjBuwY1ZtNiqoGtVs/mYB8WkcQg3MoJqAViEVbf0GPGu1hAgHwsntALeWjgHL+SxBqmYu4TvynSxU4mAtlg==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "@fluidframework/container-definitions": "^0.39.8",
+                        "@fluidframework/container-runtime-definitions": "^0.45.4",
+                        "@fluidframework/core-interfaces": "^0.39.7",
+                        "@fluidframework/datastore-definitions": "^0.45.4",
+                        "@fluidframework/garbage-collector": "^0.45.4",
+                        "@fluidframework/protocol-base": "^0.1028.1",
+                        "@fluidframework/protocol-definitions": "^0.1024.0",
+                        "@fluidframework/runtime-definitions": "^0.45.4"
+                    }
+                },
+                "@fluidframework/telemetry-utils": {
+                    "version": "0.45.4",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.45.4.tgz",
+                    "integrity": "sha512-+CFqR2hnged4MnB9zp30rWWuDZa41wNe5uCbcZ6SqHMOfAT/aSKnKdy++kYyiz2yAzVr0by9IXCYJy9H0sEN5w==",
+                    "requires": {
+                        "@fluidframework/common-definitions": "^0.20.1",
+                        "@fluidframework/common-utils": "^0.32.1",
+                        "debug": "^4.1.1",
+                        "events": "^3.1.0"
+                    }
+                },
+                "@types/node": {
+                    "version": "12.20.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+                    "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw=="
                 },
                 "uuid": {
                     "version": "8.3.2",
@@ -772,11 +1444,18 @@
             }
         },
         "@fluidframework/view-interfaces": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.43.0.tgz",
-            "integrity": "sha512-41ma3Os1heRF29dB/YBYuNF1WKLeQ5aAtjogWv1kkSR7ehLzvPaALsNB32zPjnd2IPIlLPvETAw2Pr5Flz9JPw==",
+            "version": "0.45.4",
+            "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.45.4.tgz",
+            "integrity": "sha512-rsDAjwX0GvGHboUgwKMI32X0/DZ24uaUZSjeqyN7CG24jz7wghPxDFxjL8OqXfX4JboiYwRQmV59oKw0w0pVqw==",
             "requires": {
-                "@fluidframework/core-interfaces": "^0.39.5"
+                "@fluidframework/core-interfaces": "^0.39.7"
+            },
+            "dependencies": {
+                "@fluidframework/core-interfaces": {
+                    "version": "0.39.8",
+                    "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.8.tgz",
+                    "integrity": "sha512-S5UzMPngTUSXcArpzfsVOh4p9hyKtLt3HjYCwtscTqUR+FgH0MeaUUYQQULAwqcXIIFnVfa1a4ZeT2zsRjTCpw=="
+                }
             }
         },
         "@types/anymatch": {
@@ -1281,11 +1960,6 @@
             "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
             "dev": true
         },
-        "array-filter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-            "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
-        },
         "array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1338,17 +2012,6 @@
                 }
             }
         },
-        "assert": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-            "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-            "requires": {
-                "es6-object-assign": "^1.1.0",
-                "is-nan": "^1.2.1",
-                "object-is": "^1.0.1",
-                "util": "^0.12.0"
-            }
-        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1382,14 +2045,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "available-typed-arrays": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-            "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-            "requires": {
-                "array-filter": "^1.0.0"
-            }
-        },
         "axios": {
             "version": "0.21.1",
             "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -1399,9 +2054,9 @@
             },
             "dependencies": {
                 "follow-redirects": {
-                    "version": "1.13.3",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-                    "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+                    "version": "1.14.2",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.2.tgz",
+                    "integrity": "sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA=="
                 }
             }
         },
@@ -1762,6 +2417,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
             "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.0"
@@ -2334,6 +2990,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -2722,6 +3379,7 @@
             "version": "1.18.0-next.1",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
             "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
@@ -2741,16 +3399,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
-        },
-        "es6-object-assign": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-            "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -3244,11 +3898,6 @@
             "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
             "dev": true
         },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-        },
         "forwarded": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -3388,7 +4037,8 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -3400,6 +4050,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
             "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
@@ -3482,14 +4133,10 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
-        },
-        "has-bigints": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
         },
         "has-binary2": {
             "version": "1.0.3",
@@ -3513,7 +4160,8 @@
         "has-symbols": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
         },
         "has-value": {
             "version": "1.0.0",
@@ -4011,6 +4659,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
             "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0"
             }
@@ -4020,11 +4669,6 @@
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
             "dev": true
-        },
-        "is-bigint": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-            "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -4036,18 +4680,11 @@
                 "binary-extensions": "^2.0.0"
             }
         },
-        "is-boolean-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-            "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-            "requires": {
-                "call-bind": "^1.0.0"
-            }
-        },
         "is-callable": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-            "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+            "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+            "dev": true
         },
         "is-core-module": {
             "version": "2.2.0",
@@ -4087,7 +4724,8 @@
         "is-date-object": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
@@ -4126,11 +4764,6 @@
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
         },
-        "is-generator-function": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
-            "integrity": "sha512-2Omr/twNtufVZFr1GhxjOMFPAj2sjc/dKaIqBhvo4qciXfJmITGH6ZGd8eZYNHza8t1y0e01AuqRhJwfWp26WQ=="
-        },
         "is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -4140,30 +4773,17 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-nan": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-            "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-            "requires": {
-                "call-bind": "^1.0.0",
-                "define-properties": "^1.1.3"
-            }
-        },
         "is-negative-zero": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "dev": true
         },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-number-object": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-            "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
         },
         "is-path-cwd": {
             "version": "2.2.0",
@@ -4202,6 +4822,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
             "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.1"
             }
@@ -4212,112 +4833,13 @@
             "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
             "dev": true
         },
-        "is-string": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-            "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
-        },
         "is-symbol": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
             "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.1"
-            }
-        },
-        "is-typed-array": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
-            "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
-            "requires": {
-                "available-typed-arrays": "^1.0.2",
-                "call-bind": "^1.0.2",
-                "es-abstract": "^1.18.0-next.2",
-                "foreach": "^2.0.5",
-                "has-symbols": "^1.0.1"
-            },
-            "dependencies": {
-                "call-bind": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                    "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.0.2"
-                    }
-                },
-                "es-abstract": {
-                    "version": "1.18.0-next.3",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-                    "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "has-symbols": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                        }
-                    }
-                },
-                "get-intrinsic": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-                    "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "is-callable": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-                    "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
-                },
-                "is-regex": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-                    "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "string.prototype.trimend": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-                    "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "define-properties": "^1.1.3"
-                    }
-                },
-                "string.prototype.trimstart": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-                    "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "define-properties": "^1.1.3"
-                    }
-                }
             }
         },
         "is-windows": {
@@ -4387,9 +4909,9 @@
             }
         },
         "jsrsasign": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.3.0.tgz",
-            "integrity": "sha512-irDIKKFW++EAELgP3fjFi5/Fn0XEyfuQTTgpbeFwCGkV6tRIYZl3uraRea2HTXWCstcSZuDaCbdAhU1n+075Bg=="
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.4.0.tgz",
+            "integrity": "sha512-C8qLhiAssh/b74KJpGhWuFGG9cFhJqMCVuuHXRibb3Z5vPuAW0ue0jUirpoExCdpdhv4nD3sZ1DAwJURYJTm9g=="
         },
         "jwt-decode": {
             "version": "3.1.2",
@@ -5043,12 +5565,14 @@
         "object-inspect": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+            "dev": true
         },
         "object-is": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
             "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3"
@@ -5057,7 +5581,8 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
@@ -5072,6 +5597,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
             "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3",
@@ -6754,6 +7280,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
             "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3"
@@ -6763,6 +7290,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
             "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "define-properties": "^1.1.3"
@@ -7147,17 +7675,6 @@
             "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
             "dev": true
         },
-        "unbox-primitive": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-            "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
-            "requires": {
-                "function-bind": "^1.1.1",
-                "has-bigints": "^1.0.0",
-                "has-symbols": "^1.0.0",
-                "which-boxed-primitive": "^1.0.1"
-            }
-        },
         "union-value": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -7294,19 +7811,6 @@
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
-        },
-        "util": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-            "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
-            "requires": {
-                "inherits": "^2.0.3",
-                "is-arguments": "^1.0.4",
-                "is-generator-function": "^1.0.7",
-                "is-typed-array": "^1.1.3",
-                "safe-buffer": "^5.1.2",
-                "which-typed-array": "^1.1.2"
-            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -8468,37 +8972,11 @@
                 "isexe": "^2.0.0"
             }
         },
-        "which-boxed-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "requires": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
-            }
-        },
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
-        },
-        "which-typed-array": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
-            "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
-            "requires": {
-                "available-typed-arrays": "^1.0.2",
-                "call-bind": "^1.0.0",
-                "es-abstract": "^1.18.0-next.1",
-                "foreach": "^2.0.5",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.1",
-                "is-typed-array": "^1.1.3"
-            }
         },
         "wordwrapjs": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
         "start:server": "npx tinylicious"
     },
     "dependencies": {
-        "@fluid-experimental/fluid-framework": "^0.43.0",
-        "@fluid-experimental/frs-client": "^0.43.0",
+        "@fluid-experimental/fluid-framework": "^0.45.0",
+        "@fluid-experimental/frs-client": "^0.45.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "vue": "^3.0.5"

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ async function start() {
         storage: "http://localhost:7070",
     };
 
+    // This configures the FrsClient to use a remote Azure Fluid Service instance.
     // const frsAzUser = {
     //     userId: "Test User",
     //     userName: "test-user"
@@ -29,8 +30,8 @@ async function start() {
 
     // const prodConfig: FrsConnectionConfig = {
     //     tenantId: "",
-	//     tokenProvider: new FrsAzFunctionTokenProvider("", frsAzUser),
-	//     orderer: "",
+    //     tokenProvider: new FrsAzFunctionTokenProvider("", frsAzUser),
+    //     orderer: "",
     //     storage: "",
     // };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@
  */
 
 import { ContainerSchema, ISharedMap, SharedMap } from "@fluid-experimental/fluid-framework";
-import { FrsAzFunctionTokenProvider, FrsClient, FrsConnectionConfig, FrsContainerConfig } from "@fluid-experimental/frs-client";
+import { FrsClient, FrsConnectionConfig, FrsContainerConfig, InsecureTokenProvider } from "@fluid-experimental/frs-client";
 import { getContainerId } from "./utils";
 import { vueRenderView as renderView } from "./view";
 
@@ -14,35 +14,27 @@ async function start() {
 
     // This configures the FrsClient to use a local in-memory service called Tinylicious.
     // You can run Tinylicious locally using 'npx tinylicious'.
-    // const localConfig: FrsConnectionConfig = {
-    //     tenantId: "local",
-    //     tokenProvider: new InsecureTokenProvider("anyValue", { id: "userId" }),
-    //     // if you're running Tinylicious on a non-default port, you'll need change these URLs
-    //     orderer: "http://localhost:7070",
-    //     storage: "http://localhost:7070",
-    // };
-
-    const frsAzUser = {
-        userId: "Test User",
-        userName: "test-user"
-    }
-
-    const config: FrsConnectionConfig = {
-        tenantId: "frs-client-tenant",
-	    tokenProvider: new FrsAzFunctionTokenProvider("", frsAzUser),
-	    orderer: "",
-        storage: "",
+    const localConfig: FrsConnectionConfig = {
+        tenantId: "local",
+        tokenProvider: new InsecureTokenProvider("anyValue", { id: "userId" }),
+        // if you're running Tinylicious on a non-default port, you'll need change these URLs
+        orderer: "http://localhost:7070",
+        storage: "http://localhost:7070",
     };
 
-    // This configures the FrsClient to use a remote Azure Fluid Service instance.
-    // const productionConfig: FrsConnectionConfig = {
-    //     tenantId: "myFrsTenantId",
-    //     tokenProvider: new MySecureTokenProvider(/* ... */),
-    //     orderer: "https://myFrsOrdererUrl",
-    //     storage: "https://myFrsStorageUrl",
+    // const frsAzUser = {
+    //     userId: "Test User",
+    //     userName: "test-user"
     // }
 
-    const client = new FrsClient(config);
+    // const prodConfig: FrsConnectionConfig = {
+    //     tenantId: "",
+	//     tokenProvider: new FrsAzFunctionTokenProvider("", frsAzUser),
+	//     orderer: "",
+    //     storage: "",
+    // };
+
+    const client = new FrsClient(localConfig);
 
     const containerConfig: FrsContainerConfig = { id };
     const containerSchema: ContainerSchema = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@
  */
 
 import { ContainerSchema, ISharedMap, SharedMap } from "@fluid-experimental/fluid-framework";
-import { FrsClient, FrsConnectionConfig, FrsContainerConfig, InsecureTokenProvider } from "@fluid-experimental/frs-client";
+import { FrsAzFunctionTokenProvider, FrsClient, FrsConnectionConfig, FrsContainerConfig } from "@fluid-experimental/frs-client";
 import { getContainerId } from "./utils";
 import { vueRenderView as renderView } from "./view";
 
@@ -14,12 +14,24 @@ async function start() {
 
     // This configures the FrsClient to use a local in-memory service called Tinylicious.
     // You can run Tinylicious locally using 'npx tinylicious'.
-    const localConfig: FrsConnectionConfig = {
-        tenantId: "local",
-        tokenProvider: new InsecureTokenProvider("anyValue", { id: "userId" }),
-        // if you're running Tinylicious on a non-default port, you'll need change these URLs
-        orderer: "http://localhost:7070",
-        storage: "http://localhost:7070",
+    // const localConfig: FrsConnectionConfig = {
+    //     tenantId: "local",
+    //     tokenProvider: new InsecureTokenProvider("anyValue", { id: "userId" }),
+    //     // if you're running Tinylicious on a non-default port, you'll need change these URLs
+    //     orderer: "http://localhost:7070",
+    //     storage: "http://localhost:7070",
+    // };
+
+    const frsAzUser = {
+        userId: "Test User",
+        userName: "test-user"
+    }
+
+    const config: FrsConnectionConfig = {
+        tenantId: "frs-client-tenant",
+	    tokenProvider: new FrsAzFunctionTokenProvider("", frsAzUser),
+	    orderer: "",
+        storage: "",
     };
 
     // This configures the FrsClient to use a remote Azure Fluid Service instance.
@@ -30,7 +42,7 @@ async function start() {
     //     storage: "https://myFrsStorageUrl",
     // }
 
-    const client = new FrsClient(localConfig);
+    const client = new FrsClient(config);
 
     const containerConfig: FrsContainerConfig = { id };
     const containerSchema: ContainerSchema = {
@@ -40,7 +52,7 @@ async function start() {
 
     const { fluidContainer } = isNew
         ? await client.createContainer(containerConfig, containerSchema)
-        : await client.getContainer(containerConfig, containerSchema);
+        : await client.getContainer(containerConfig, containerSchema)
 
     renderView(
         fluidContainer.initialObjects.dice as ISharedMap,

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,7 +45,7 @@ async function start() {
 
     const { fluidContainer } = isNew
         ? await client.createContainer(containerConfig, containerSchema)
-        : await client.getContainer(containerConfig, containerSchema)
+        : await client.getContainer(containerConfig, containerSchema);
 
     renderView(
         fluidContainer.initialObjects.dice as ISharedMap,


### PR DESCRIPTION
In this PR, the Fluid Framework dependencies version is changed from 0.43 to 0.45. The `FluidHelloWorld` is running against FRS instead of Tinylicious. 