### PR TITLE
Update README to require a minimum node version of 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ walkthrough of this example and how it works, check out the [tutorial documentat
 
 ## Requirements
 
-Node 12.17+
+Node 14.19+
 
 ## Getting Started
 


### PR DESCRIPTION
The README currently states that the minimum version of node required is v12. However, when using node v12, the server fails to start on `npm start`. Installing the node modules also takes an incredibly long time for v12. Last, it looks like Node v12 is no longer maintained according to https://nodejs.org/en/about/releases/. 

So I'm updating the README to require a minimum of version 14 for node.