### PR TITLE
Bump to latest fluid framework and pin tinylicious

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -394,6 +394,23 @@
         "minimist": "^1.2.0"
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true
+    },
+    "@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz",
@@ -401,25 +418,25 @@
       "dev": true
     },
     "@fluidframework/aqueduct": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.5.tgz",
-      "integrity": "sha512-9wpP2xmOdrGsgAnc/ZgX9JnxqYv9SHC8ubauhTa0lHlWYdyvJVu+gO+reVNVkHSGq7DQZl4Sg5j4ly8mAs1o1A==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.3.6.tgz",
+      "integrity": "sha512-33vWqX1UEwYYTHb3Iv6+1B4ZFFcPNdD3cqfAmYbR7nOwxPYq1uKflUzafUOKW6SMpRyomeebCy/f5/PIoG+yJA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-loader": "^1.2.5",
-        "@fluidframework/container-runtime": "^1.2.5",
-        "@fluidframework/container-runtime-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
-        "@fluidframework/map": "^1.2.5",
-        "@fluidframework/request-handler": "^1.2.5",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/synthesize": "^1.2.5",
-        "@fluidframework/view-interfaces": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-loader": "^1.3.6",
+        "@fluidframework/container-runtime": "^1.3.6",
+        "@fluidframework/container-runtime-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
+        "@fluidframework/map": "^1.3.6",
+        "@fluidframework/request-handler": "^1.3.6",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/synthesize": "^1.3.6",
+        "@fluidframework/view-interfaces": "^1.3.6",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -442,47 +459,62 @@
       "integrity": "sha512-KaoQ7w2MDH5OeRKVatL5yVOCFg+9wD6bLSLFh1/TV1EZM46l49iBqO7UVjUtPE6BIm0jvvOzJXULGVSpzokX3g=="
     },
     "@fluidframework/common-utils": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.1.tgz",
-      "integrity": "sha512-8m7nTGLyzQqjGX9qZmE1L65IfSxrcEo35MtCVmH0qfttfVqEFghxXAgtmrcfvKkg6NUDTmb13hdyNx0hZlky7w==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-0.32.2.tgz",
+      "integrity": "sha512-PoGX7/l0vWKt5JaAxcgFOdGje30Q6qSE06YzFIKh9Ba3oq7B60+TFqu7c2ErQt6sNddmvcAcAiLVNaTGAip3vw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@types/events": "^3.0.0",
         "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
         "events": "^3.1.0",
         "lodash": "^4.17.21",
         "sha.js": "^2.4.11"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.5.tgz",
-      "integrity": "sha512-11prpsstqz32XkO4Iy828hS2VpJE5Nv+h54GA9uLpbeUjMHe8tBxaYsXjTmAvV9954iomtk3KBzBv7x3da969g==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.3.6.tgz",
+      "integrity": "sha512-+5fuIUG7jGjKrRHtrH2VgrRI0YUXcP9jSLrHdI4Ks+4kNSDiOlu+UT7j9T9KoBAfHOpnihS3PVeDBJtIeqgDZw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/protocol-definitions": "^0.1028.2000"
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/protocol-definitions": "^0.1028.2000",
+        "events": "^3.1.0"
       }
     },
     "@fluidframework/container-loader": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.5.tgz",
-      "integrity": "sha512-uxemA6EbF5jnAFEU+8flBgkASMi4IdlQAwX1idIjJlBGlJ6la/u1YwFlLXFFOL6zo4l92PFK9O/or7VHNdXHGQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.3.6.tgz",
+      "integrity": "sha512-J7nF7XTHCtL24gGnUhg155kolokX8HRWJqj2XEjaPrBsRmkyiySP+qCnrKY0bgLqaFLHW4WYfmC80lFE3oaELg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "abort-controller": "^3.0.0",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "lodash": "^4.17.21",
+        "url": "^0.11.0",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -494,26 +526,27 @@
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.5.tgz",
-      "integrity": "sha512-sa/RRhG3v5zYNxWWrp7mnDrLrh+AJqgvQGUnXijZaxpktB0THoXbSJezji7wym8uzmCIkbOB6P1Kxgu6ktdoAA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.3.6.tgz",
+      "integrity": "sha512-YC1Bvd8UiO3YID/sU9yxMMibW0FPqpf+sS47Czg1ILf2twK48U2BopDDKNeIHJFDl3yNOqxJniUkJJLNoYWwqg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-runtime-definitions": "^1.2.5",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
-        "@fluidframework/garbage-collector": "^1.2.5",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-runtime-definitions": "^1.3.6",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
+        "@fluidframework/garbage-collector": "^1.3.6",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -525,62 +558,54 @@
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.5.tgz",
-      "integrity": "sha512-+TJk0o8fU8dZmYmb33Dv6ZLWUQhZzB/aWdBWoZagekSxT/upaDP21WoxkPJ9CWHZvp3GvFTfvMWKlUoq1gMW8A==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.3.6.tgz",
+      "integrity": "sha512-cQP/F2F9BjeXKyUNmwQCRRb5qJPoufZ/iIyBSdj8qEYwhTyv3Ogbk+LyHz5cG8wPYlM2ff8IirxwEdgq7VTL/w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@types/node": "^14.18.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        }
+        "@fluidframework/runtime-definitions": "^1.3.6"
       }
     },
     "@fluidframework/container-utils": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.5.tgz",
-      "integrity": "sha512-ZMQwYMCjv253nN7QvouRhOk1nr5NEyR/HBeeyOePdlp/LJ9qCKZb1kwOgirPr401J6crm+ZlKaE3HNnLcRcx6Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.3.6.tgz",
+      "integrity": "sha512-Hf3kxHuRzQv3a7J+I/3q5OH3WW5lajy3ENucc1HLCuOKYi39MM5AfAMBEfaTl1aI5iMxhHEyDAZJhaGJvvgOew==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.2.5"
+        "@fluidframework/telemetry-utils": "^1.3.6"
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.5.tgz",
-      "integrity": "sha512-ANv7NpLQPTzYBZK9b7CbkxDI62MTFN51Zs/qkwWKOYFfTqOiCEHGM3/tU2+0xoH3VaQboNIJW9HxPvIko3PJkA=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.3.6.tgz",
+      "integrity": "sha512-6ccflpLJvlPhZ58MiMUUC5XvWF1s5yTmP3dXHsJf514IzuAvS5PCGLdZWUjWCgxA2fPvZKzA4VfWpwyFt1H0LA=="
     },
     "@fluidframework/datastore": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.5.tgz",
-      "integrity": "sha512-29TQ+gvl3b0s10CbwHZTw+SJ34DfpFHhnNsPTWQpglXosBJZWRS2gM7nsoS5XDfvG241eLmaWaOMc4xo1jXCgw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.3.6.tgz",
+      "integrity": "sha512-eQTkB/Z0Sn5JwZ66EvY3r4RflSoZth0Zi7ezD4kbx75c4wmixRSs+qGSMM0xbllFXjyA24ucbL21zduVLxZGcg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
-        "@fluidframework/garbage-collector": "^1.2.5",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
+        "@fluidframework/garbage-collector": "^1.3.6",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
       },
@@ -593,62 +618,54 @@
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.5.tgz",
-      "integrity": "sha512-zgTMPgYpOakQ1S0jaPL7dUzFGJFxI56hvPYQzrHE70m5926zqMJvdDEhoTK+pj8opKbol8NDC0iZVRtR0/Pwhw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.3.6.tgz",
+      "integrity": "sha512-9kgqa5FsIHHuxQPL50cm/FX6FOukBDDHG45ByGEChISbnfkS13xncLrY6mE4FgTC1jW0d7y3CgGT3pn4n9Hc+g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@types/node": "^14.18.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        }
+        "@fluidframework/runtime-definitions": "^1.3.6"
       }
     },
     "@fluidframework/driver-base": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.2.5.tgz",
-      "integrity": "sha512-wxU9qCR3897k5vwZt4xYkXllFa4RtQzjQTi54LMmUmo4iA/luAeAl+n7tLyCYxIIYaXoXkaBRQhjSADuqD3w7Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-1.3.6.tgz",
+      "integrity": "sha512-Ini7PyyIP+out9+5eAqq+QYWfxSGprVtxTrtipmoKCjI6XTmgfmSwrs9VPrgdIl6lI52RjEFWQtC/J3vmjAesg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.2.5"
+        "@fluidframework/telemetry-utils": "^1.3.6"
       }
     },
     "@fluidframework/driver-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.5.tgz",
-      "integrity": "sha512-cSExTm0mWBz0I6NnUyIAuYJDiHqMY4Jg8Up8VYevfdaCnbUVNRSxUC806PL81KtGxgaCDUVf1NVGG6Ao6GsJAg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.3.6.tgz",
+      "integrity": "sha512-5Rvk2NhXxh2bhk8WWnBtcJq/9TgVYhAj4z7DDuqXqJyRUF/XYhyxqOfMuo7IAhTa2oTpp8o7QDwZqsfWKfC9tA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/core-interfaces": "^1.2.5",
+        "@fluidframework/core-interfaces": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.5.tgz",
-      "integrity": "sha512-AvDkUMbFV2Se+TaSmL/9lGop9ZNV7yESDxYNj4uU6KNB+OPrvcctX4kdNACZQuUIUXAobYIVK/mQirh3qSSufg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.3.6.tgz",
+      "integrity": "sha512-yDbuR4eMj0Y+kbIwV0XaXd3kh+U1YxmU1Qgcxa2RgD3MEMsDiCBaQrUCPjjxmBT9diUfBijVxjjOc5vUfm/eBA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/gitresources": "^0.1036.5000",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "axios": "^0.26.0",
         "uuid": "^8.3.1"
       },
@@ -674,335 +691,82 @@
       }
     },
     "@fluidframework/fluid-static": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.5.tgz",
-      "integrity": "sha512-hI7WM/9NjhSMSYAvAOh+WxuQ9FCzq+qQ54p58NkYKuHwo1eQ36CVfQyTUjh5VXsO7ubSvKCKAlbuqRHXBI0eIQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.3.6.tgz",
+      "integrity": "sha512-ncGgaDmewFQJou9roh+8K94hhpIlNEGvLaxNnofgFHAq1R2vLlx+zb5VGMMywnof+gvjgrsk4JOP2C9XpMs9Tw==",
       "requires": {
-        "@fluidframework/aqueduct": "^1.2.5",
+        "@fluidframework/aqueduct": "^1.3.6",
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-loader": "^1.2.5",
-        "@fluidframework/container-runtime-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-loader": "^1.3.6",
+        "@fluidframework/container-runtime-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/request-handler": "^1.2.5",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5"
+        "@fluidframework/request-handler": "^1.3.6",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6"
       }
     },
     "@fluidframework/garbage-collector": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.5.tgz",
-      "integrity": "sha512-lTSStL2tJGnigFs09o/bUrEC+7SfZXVXF4tIVfcXPQ1yNSDofzWDLdovA7OLuKUIdMVKXgdNSVohHprgpAbuKw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.3.6.tgz",
+      "integrity": "sha512-uJpvkWNzTsLJAmGwu6LUjR8cVoAzlfmhxoudaGrA3DeWhGheDcGVP/hiKht+pMw3u1CCA4AKOfE+0bIOQXyFBA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/runtime-definitions": "^1.2.5"
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/runtime-definitions": "^1.3.6"
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1036.5000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
-      "integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
+      "version": "0.1036.5001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5001.tgz",
+      "integrity": "sha512-Beg1A/eR7wCPYYb5u5iqqc092NkWnSvl4XCn2ImA4FDKtnYggD2/KYd9Hp0feM6Z99aU4FYSBidL2NewWlvF7A=="
     },
     "@fluidframework/map": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.5.tgz",
-      "integrity": "sha512-MDKsQarfwCwujEba2/4bJqp+LwKUWPaB20zK2FRXLO09Vq11Anu/0yhker94UpiSGmEaXjJ0GZ3vpdXRy2Pukg==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.3.6.tgz",
+      "integrity": "sha512-CEuDHKLbJGt8SwwyUKoY1ZBkeFcn7Y+XPbm6lqsctYM08Fz2n1IsI6cl7KqppR3xJ2SpGyzDnVzNXeiPyOapfQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/shared-object-base": "^1.2.5",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/shared-object-base": "^1.3.6",
         "path-browserify": "^1.0.1"
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.2.5.tgz",
-      "integrity": "sha512-P7ug3gnW29YHZ3k+HhA60MqzFtZenXz4Eg+SwoswrgO/Xo9JdL4/CSxyrvIi/jJQnxtgfPkqbisc2eo355sQ5Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-1.3.6.tgz",
+      "integrity": "sha512-a7ZYHpbKO5as+SxKbiqAlxYXK/vmaWY0A8n1O5dTjgElHaJkuxaKKczczr9tBrAxQ7JYNZ0Sq3e6n5hm2gfU4g==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/shared-object-base": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5"
-      },
-      "dependencies": {
-        "@fluidframework/container-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.5.tgz",
-          "integrity": "sha512-11prpsstqz32XkO4Iy828hS2VpJE5Nv+h54GA9uLpbeUjMHe8tBxaYsXjTmAvV9954iomtk3KBzBv7x3da969g==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/container-runtime": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.5.tgz",
-          "integrity": "sha512-sa/RRhG3v5zYNxWWrp7mnDrLrh+AJqgvQGUnXijZaxpktB0THoXbSJezji7wym8uzmCIkbOB6P1Kxgu6ktdoAA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "double-ended-queue": "^2.1.0-0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/container-runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-+TJk0o8fU8dZmYmb33Dv6ZLWUQhZzB/aWdBWoZagekSxT/upaDP21WoxkPJ9CWHZvp3GvFTfvMWKlUoq1gMW8A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/container-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.5.tgz",
-          "integrity": "sha512-ZMQwYMCjv253nN7QvouRhOk1nr5NEyR/HBeeyOePdlp/LJ9qCKZb1kwOgirPr401J6crm+ZlKaE3HNnLcRcx6Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/core-interfaces": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.5.tgz",
-          "integrity": "sha512-ANv7NpLQPTzYBZK9b7CbkxDI62MTFN51Zs/qkwWKOYFfTqOiCEHGM3/tU2+0xoH3VaQboNIJW9HxPvIko3PJkA=="
-        },
-        "@fluidframework/datastore": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.5.tgz",
-          "integrity": "sha512-29TQ+gvl3b0s10CbwHZTw+SJ34DfpFHhnNsPTWQpglXosBJZWRS2gM7nsoS5XDfvG241eLmaWaOMc4xo1jXCgw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "lodash": "^4.17.21",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/datastore-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.5.tgz",
-          "integrity": "sha512-zgTMPgYpOakQ1S0jaPL7dUzFGJFxI56hvPYQzrHE70m5926zqMJvdDEhoTK+pj8opKbol8NDC0iZVRtR0/Pwhw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/driver-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.5.tgz",
-          "integrity": "sha512-cSExTm0mWBz0I6NnUyIAuYJDiHqMY4Jg8Up8VYevfdaCnbUVNRSxUC806PL81KtGxgaCDUVf1NVGG6Ao6GsJAg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/driver-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.5.tgz",
-          "integrity": "sha512-AvDkUMbFV2Se+TaSmL/9lGop9ZNV7yESDxYNj4uU6KNB+OPrvcctX4kdNACZQuUIUXAobYIVK/mQirh3qSSufg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "axios": "^0.26.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/garbage-collector": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.5.tgz",
-          "integrity": "sha512-lTSStL2tJGnigFs09o/bUrEC+7SfZXVXF4tIVfcXPQ1yNSDofzWDLdovA7OLuKUIdMVKXgdNSVohHprgpAbuKw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/runtime-definitions": "^1.2.5"
-          }
-        },
-        "@fluidframework/gitresources": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
-          "integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
-        },
-        "@fluidframework/protocol-base": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
-          "integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
-          "requires": {
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.2000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-          "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        },
-        "@fluidframework/runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-j38odkSWNy4MSFGY7HWbxUm/GSD/V7DCDoxtE1ohieswyLyeHLZTCf7IxQuOZk1exbxSOUYJg/89yxFEWSpTvw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/runtime-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.5.tgz",
-          "integrity": "sha512-RVjI6AvXXwmQ0MbtF22qgre/OnV5ul3kQOcBjBWm2ZikkqyEwdpSzLQhqRMVToJDUrZ4RTinox/qQlSBr3qtbQ==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/shared-object-base": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.5.tgz",
-          "integrity": "sha512-dnrfl1pYGh5Pe19XWkdz2wYRmX92pw6kpwZ0zFxEvGryWLZXcd4MWqljknTBPMwBxeKj7+8RiLN9E6iJFC4n4Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/telemetry-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.5.tgz",
-          "integrity": "sha512-red4y9zabiYDeHqMEwnMkFuw/mW2rKI2TbiSUDAuPC8hiZp+T8ovF/GXp/mB1XzXbBJ2ZnW9+IMV0OcM5pib0A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "debug": "^4.1.1",
-            "events": "^3.1.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        },
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.15.2",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/shared-object-base": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6"
       }
     },
     "@fluidframework/protocol-base": {
-      "version": "0.1036.5000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
-      "integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
+      "version": "0.1036.5001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5001.tgz",
+      "integrity": "sha512-Btjy2bWVbVsmzNTBxTQZ9l/WXljsjDpGbBgJsn9GLacrTG9aDDtIVMXuwLAcEV1IVkxGcIipXryvfhbPHDYcMg==",
       "requires": {
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/gitresources": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
         "lodash": "^4.17.21"
       }
@@ -1016,32 +780,32 @@
       }
     },
     "@fluidframework/request-handler": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.5.tgz",
-      "integrity": "sha512-ua/ssLobf+1wEAlZyEvQcbGbTxtZXFBDZtnjeYKilY47NDt1gV99dIpKRZrLs8yFyTNHGXEXD9hv8w6OOqfQmQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.3.6.tgz",
+      "integrity": "sha512-4z0XRVuj3mu6ZYceUbTf/DZfRt1u0cClnpVZPthEs26QSk6LJvEpt5UBE3oIGkESoxZ3LHtAnkS2zCEl8jcrFw==",
       "requires": {
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-runtime-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5"
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-runtime-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6"
       }
     },
     "@fluidframework/routerlicious-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.2.5.tgz",
-      "integrity": "sha512-O1MSKe1kFQXsmIiM6kQpYel9BUK6Z9OXe4I11gZo1/Do9f40yRzoyA+AkNRiimLZgzBvTlWhzE5Cfji5jT4O3Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-1.3.6.tgz",
+      "integrity": "sha512-b9NXLWI7YH4l2dEkgjDuIF9BNb1ggxkzS8ZtZpr+eBtegRN+E+WSbkR7JCPwrDmA+vPa9z0mXNS88ZeCwnQp3A==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/driver-base": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
-        "@fluidframework/gitresources": "^0.1036.5000",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/driver-base": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
+        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/server-services-client": "^0.1036.5000",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/server-services-client": "^0.1036.5001",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "cross-fetch": "^3.1.5",
         "json-stringify-safe": "5.0.1",
         "querystring": "^0.2.0",
@@ -1067,309 +831,55 @@
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.5.tgz",
-      "integrity": "sha512-j38odkSWNy4MSFGY7HWbxUm/GSD/V7DCDoxtE1ohieswyLyeHLZTCf7IxQuOZk1exbxSOUYJg/89yxFEWSpTvw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.3.6.tgz",
+      "integrity": "sha512-sFCUkN4sCz1ww7XKhIFiiXuaUtrps8Dd4h0VaYLsvzkH9bD/lcbbcvgmaMmqPa3tOy0ROsLAM5QSr5jBYipidw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@types/node": "^14.18.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        }
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/protocol-definitions": "^0.1028.2000"
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.5.tgz",
-      "integrity": "sha512-RVjI6AvXXwmQ0MbtF22qgre/OnV5ul3kQOcBjBWm2ZikkqyEwdpSzLQhqRMVToJDUrZ4RTinox/qQlSBr3qtbQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.3.6.tgz",
+      "integrity": "sha512-Yl0oWTcUwgDBWIaW6UsyfHE9D5yhmY11lx5ij3RcEn2Up07mD7+DzFXvxXTjdCioc4B0ssad70vvGJKJOwk6Nw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-runtime-definitions": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
-        "@fluidframework/garbage-collector": "^1.2.5",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-runtime-definitions": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
+        "@fluidframework/garbage-collector": "^1.3.6",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5"
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6"
       }
     },
     "@fluidframework/sequence": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.2.5.tgz",
-      "integrity": "sha512-x3X3ecB4CUIdcFB/0bUE2sViZQzTtf51qeA87/unXlhJ/sAyY9g1MH9glFZtQ7Wxjutrc+gtYOxLj8DE+PpwrA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-1.3.6.tgz",
+      "integrity": "sha512-XGtwifGkakcUxAnaEyM23CaG/avK1a87odb2uhbiwP2k3g55aSe2PsOhmtJVVrs1Yv775Xc1jGUotRKiNzLY7w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
-        "@fluidframework/merge-tree": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
+        "@fluidframework/merge-tree": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/shared-object-base": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/shared-object-base": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "uuid": "^8.3.1"
       },
       "dependencies": {
-        "@fluidframework/container-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.5.tgz",
-          "integrity": "sha512-11prpsstqz32XkO4Iy828hS2VpJE5Nv+h54GA9uLpbeUjMHe8tBxaYsXjTmAvV9954iomtk3KBzBv7x3da969g==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/container-runtime": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.5.tgz",
-          "integrity": "sha512-sa/RRhG3v5zYNxWWrp7mnDrLrh+AJqgvQGUnXijZaxpktB0THoXbSJezji7wym8uzmCIkbOB6P1Kxgu6ktdoAA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "double-ended-queue": "^2.1.0-0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/container-runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-+TJk0o8fU8dZmYmb33Dv6ZLWUQhZzB/aWdBWoZagekSxT/upaDP21WoxkPJ9CWHZvp3GvFTfvMWKlUoq1gMW8A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/container-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.5.tgz",
-          "integrity": "sha512-ZMQwYMCjv253nN7QvouRhOk1nr5NEyR/HBeeyOePdlp/LJ9qCKZb1kwOgirPr401J6crm+ZlKaE3HNnLcRcx6Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/core-interfaces": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.5.tgz",
-          "integrity": "sha512-ANv7NpLQPTzYBZK9b7CbkxDI62MTFN51Zs/qkwWKOYFfTqOiCEHGM3/tU2+0xoH3VaQboNIJW9HxPvIko3PJkA=="
-        },
-        "@fluidframework/datastore": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.5.tgz",
-          "integrity": "sha512-29TQ+gvl3b0s10CbwHZTw+SJ34DfpFHhnNsPTWQpglXosBJZWRS2gM7nsoS5XDfvG241eLmaWaOMc4xo1jXCgw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "lodash": "^4.17.21",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/datastore-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.5.tgz",
-          "integrity": "sha512-zgTMPgYpOakQ1S0jaPL7dUzFGJFxI56hvPYQzrHE70m5926zqMJvdDEhoTK+pj8opKbol8NDC0iZVRtR0/Pwhw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/driver-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.5.tgz",
-          "integrity": "sha512-cSExTm0mWBz0I6NnUyIAuYJDiHqMY4Jg8Up8VYevfdaCnbUVNRSxUC806PL81KtGxgaCDUVf1NVGG6Ao6GsJAg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/driver-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.5.tgz",
-          "integrity": "sha512-AvDkUMbFV2Se+TaSmL/9lGop9ZNV7yESDxYNj4uU6KNB+OPrvcctX4kdNACZQuUIUXAobYIVK/mQirh3qSSufg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "axios": "^0.26.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/garbage-collector": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.5.tgz",
-          "integrity": "sha512-lTSStL2tJGnigFs09o/bUrEC+7SfZXVXF4tIVfcXPQ1yNSDofzWDLdovA7OLuKUIdMVKXgdNSVohHprgpAbuKw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/runtime-definitions": "^1.2.5"
-          }
-        },
-        "@fluidframework/gitresources": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
-          "integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
-        },
-        "@fluidframework/protocol-base": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
-          "integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
-          "requires": {
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.2000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-          "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        },
-        "@fluidframework/runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-j38odkSWNy4MSFGY7HWbxUm/GSD/V7DCDoxtE1ohieswyLyeHLZTCf7IxQuOZk1exbxSOUYJg/89yxFEWSpTvw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/runtime-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.5.tgz",
-          "integrity": "sha512-RVjI6AvXXwmQ0MbtF22qgre/OnV5ul3kQOcBjBWm2ZikkqyEwdpSzLQhqRMVToJDUrZ4RTinox/qQlSBr3qtbQ==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/shared-object-base": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.5.tgz",
-          "integrity": "sha512-dnrfl1pYGh5Pe19XWkdz2wYRmX92pw6kpwZ0zFxEvGryWLZXcd4MWqljknTBPMwBxeKj7+8RiLN9E6iJFC4n4Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/telemetry-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.5.tgz",
-          "integrity": "sha512-red4y9zabiYDeHqMEwnMkFuw/mW2rKI2TbiSUDAuPC8hiZp+T8ovF/GXp/mB1XzXbBJ2ZnW9+IMV0OcM5pib0A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "debug": "^4.1.1",
-            "events": "^3.1.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        },
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.15.2",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1377,14 +887,601 @@
         }
       }
     },
-    "@fluidframework/server-services-client": {
-      "version": "0.1036.5000",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5000.tgz",
-      "integrity": "sha512-TBig0U1Fne0h10H6Sylcf6pe9PrYJy6PkLvTv+MX9ojuWsyPJbbhkPX/L2Gj/wmzDY+psvhA2TSLDZOMnpshpw==",
+    "@fluidframework/server-lambdas": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1038.4001.tgz",
+      "integrity": "sha512-rERfgXK5DXGJvxADjotkAZssKgp3ZxW6u7yUekrDnFDkXtbCW1Gcq+EwvjHTEyhsOp30YBnD0Z39xnZy4zEZRw==",
+      "dev": true,
       "requires": {
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/gitresources": "^0.1036.5000",
-        "@fluidframework/protocol-base": "^0.1036.5000",
+        "@fluidframework/common-definitions": "^0.20.1",
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1038.4001",
+        "@fluidframework/protocol-base": "^0.1038.4001",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-lambdas-driver": "^0.1038.4001",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "@types/semver": "^6.0.1",
+        "assert": "^2.0.0",
+        "async": "^3.2.2",
+        "axios": "^0.26.0",
+        "buffer": "^6.0.3",
+        "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "nconf": "^0.12.0",
+        "semver": "^6.3.0",
+        "sha.js": "^2.4.11",
+        "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "dev": true,
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-lambdas-driver": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas-driver/-/server-lambdas-driver-0.1038.4001.tgz",
+      "integrity": "sha512-qRs+vMbSS9aPx7vr3XemvER5DeY/nsJ5ZkcL3UDjUOxvLZxbOAD6C6JeH3Zgzc/jc8bqshcxai/u7qso2zCsFw==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "assert": "^2.0.0",
+        "async": "^3.2.2",
+        "events": "^3.1.0",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "dev": true,
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-local-server": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1038.4001.tgz",
+      "integrity": "sha512-FIlNUc9Ncul/5qzP+VyU53TJj8fxX7KZ1lweswZYalleRZwiqFA4Y+NbWRRWM0iJ1z8hvhyRZblG3iNrpGl04A==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-lambdas": "^0.1038.4001",
+        "@fluidframework/server-memory-orderer": "^0.1038.4001",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "@fluidframework/server-test-utils": "^0.1038.4001",
+        "debug": "^4.1.1",
+        "events": "^3.1.0",
+        "jsrsasign": "^10.5.25",
+        "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-memory-orderer": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1038.4001.tgz",
+      "integrity": "sha512-fdzTCLFRh8QfyY17MnB22/o8x2XEX1+wZrm+dn+1Av+ZVe/+ZhfdX5LsQCMKYv+X5mgAauNmC/12mQE4H6jvsQ==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/protocol-base": "^0.1038.4001",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-lambdas": "^0.1038.4001",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "@types/debug": "^4.1.5",
+        "@types/double-ended-queue": "^2.1.0",
+        "@types/lodash": "^4.14.118",
+        "@types/node": "^14.18.0",
+        "@types/ws": "^6.0.1",
+        "assert": "^2.0.0",
+        "debug": "^4.1.1",
+        "double-ended-queue": "^2.1.0-0",
+        "events": "^3.1.0",
+        "lodash": "^4.17.21",
+        "sillyname": "^0.1.0",
+        "uuid": "^8.3.1",
+        "ws": "^7.4.6"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@types/node": {
+          "version": "14.18.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
+          "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
+          "dev": true
+        },
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "dev": true,
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-services-client": {
+      "version": "0.1036.5001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1036.5001.tgz",
+      "integrity": "sha512-e+Zk2uPcds9yqlalAZ0PpfEAKPPUIpIoQb3YSm42ZVpAgQmLYIRqTpXrmTC7qdeQnSGFJUAliW4DfHBEwpSXlQ==",
+      "requires": {
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/gitresources": "^0.1036.5001",
+        "@fluidframework/protocol-base": "^0.1036.5001",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
         "axios": "^0.26.0",
         "crc-32": "1.2.0",
@@ -1417,23 +1514,886 @@
         }
       }
     },
+    "@fluidframework/server-services-core": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1038.4001.tgz",
+      "integrity": "sha512-nuZ9ebvyeIoRdlpQQpBNGkawKtc2/tHKbc8CHbMZRMh7F7kwYUtoHd/J8powb9eUcg5IHDmXx1l+PQRbQX4vCg==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1038.4001",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "@types/nconf": "^0.10.2",
+        "@types/node": "^14.18.0",
+        "debug": "^4.1.1",
+        "events": "^3.1.0",
+        "nconf": "^0.12.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@types/node": {
+          "version": "14.18.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
+          "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg==",
+          "dev": true
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-services-shared": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-shared/-/server-services-shared-0.1038.4001.tgz",
+      "integrity": "sha512-vDRB2G/Xnuhan+Ri0Eg5JMKfsm7hxstCXdEyQhzJzC7+bw66wts+ZIsEsn4Ha/3KkxblF/RSW3lBhrYpxii3cQ==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1038.4001",
+        "@fluidframework/protocol-base": "^0.1038.4001",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "@socket.io/redis-adapter": "^7.2.0",
+        "body-parser": "^1.17.1",
+        "debug": "^4.1.1",
+        "events": "^3.1.0",
+        "ioredis": "^4.24.2",
+        "lodash": "^4.17.21",
+        "nconf": "^0.12.0",
+        "notepack.io": "^2.3.0",
+        "querystring": "^0.2.0",
+        "socket.io": "^4.5.3",
+        "socket.io-adapter": "^2.4.0",
+        "socket.io-parser": "^4.2.1",
+        "uuid": "^8.3.1",
+        "winston": "^3.6.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-services-telemetry": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-telemetry/-/server-services-telemetry-0.1038.4001.tgz",
+      "integrity": "sha512-2leJhB04+71RTmC5ShRXm/4FWng9tLn9dlrUAjApZH4RlUJAx1JGsvo/5JU1tIbpUutMHUle2IpWyfu/RV+S5g==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "json-stringify-safe": "^5.0.1",
+        "path-browserify": "^1.0.1",
+        "serialize-error": "^8.1.0",
+        "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-services-utils": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-utils/-/server-services-utils-0.1038.4001.tgz",
+      "integrity": "sha512-K7X/0mlonDAu0pPIgTz8U9nLwRSbJY2oBpFPwpkp1UtE6SU02jx2ZzraT9epDmOl3EXeS1rHzA+mbvBSe1aFMg==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "debug": "^4.1.1",
+        "express": "^4.17.3",
+        "ioredis": "^4.24.2",
+        "json-stringify-safe": "^5.0.1",
+        "jsonwebtoken": "^9.0.0",
+        "morgan": "^1.8.1",
+        "nconf": "^0.12.0",
+        "serialize-error": "^8.1.0",
+        "sillyname": "^0.1.0",
+        "split": "^1.0.0",
+        "uuid": "^8.3.1",
+        "winston": "^3.6.0",
+        "winston-transport": "^4.5.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "accepts": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+          "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+          "dev": true,
+          "requires": {
+            "mime-types": "~2.1.34",
+            "negotiator": "0.6.3"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "body-parser": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.11.0",
+            "raw-body": "2.5.1",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "bytes": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+          "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.2.1"
+          }
+        },
+        "cookie": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+          "dev": true
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "destroy": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+          "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+          "dev": true
+        },
+        "express": {
+          "version": "4.18.2",
+          "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+          "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+          "dev": true,
+          "requires": {
+            "accepts": "~1.3.8",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.20.1",
+            "content-disposition": "0.5.4",
+            "content-type": "~1.0.4",
+            "cookie": "0.5.0",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.2.0",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.7",
+            "qs": "6.11.0",
+            "range-parser": "~1.2.1",
+            "safe-buffer": "5.2.1",
+            "send": "0.18.0",
+            "serve-static": "1.15.0",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "type-is": "~1.6.18",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+          "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "2.4.1",
+            "parseurl": "~1.3.3",
+            "statuses": "2.0.1",
+            "unpipe": "~1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+          "dev": true,
+          "requires": {
+            "depd": "2.0.0",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
+          }
+        },
+        "mime-db": {
+          "version": "1.52.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.35",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.52.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        },
+        "negotiator": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+          "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+          "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "qs": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "dev": true,
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        },
+        "send": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+          "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "mime": "1.6.0",
+            "ms": "2.1.3",
+            "on-finished": "2.4.1",
+            "range-parser": "~1.2.1",
+            "statuses": "2.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              },
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                  "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+                  "dev": true
+                }
+              }
+            },
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+              "dev": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+          "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+          "dev": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.3",
+            "send": "0.18.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+          "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+          "dev": true
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "dev": true,
+          "requires": {
+            "through": "2"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        },
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
+    "@fluidframework/server-test-utils": {
+      "version": "0.1038.4001",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1038.4001.tgz",
+      "integrity": "sha512-qrLp5H1UUPIJSEHlzZ1iYlPFJCQrd2WnmoafxnQIg0mfU1ZE8XUlG5MKUg8bT9pWsCoEGJDiOkkRHaq+WXupjQ==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.1.1",
+        "@fluidframework/gitresources": "^0.1038.4001",
+        "@fluidframework/protocol-base": "^0.1038.4001",
+        "@fluidframework/protocol-definitions": "^1.1.0",
+        "@fluidframework/server-services-client": "^0.1038.4001",
+        "@fluidframework/server-services-core": "^0.1038.4001",
+        "@fluidframework/server-services-telemetry": "^0.1038.4001",
+        "assert": "^2.0.0",
+        "debug": "^4.1.1",
+        "events": "^3.1.0",
+        "lodash": "^4.17.21",
+        "string-hash": "^1.1.3",
+        "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "dev": true,
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
+      }
+    },
     "@fluidframework/shared-object-base": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.5.tgz",
-      "integrity": "sha512-dnrfl1pYGh5Pe19XWkdz2wYRmX92pw6kpwZ0zFxEvGryWLZXcd4MWqljknTBPMwBxeKj7+8RiLN9E6iJFC4n4Q==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.3.6.tgz",
+      "integrity": "sha512-eUMtIosNBwDJXpw69BJuOLGJw4Lf53f6sU6ZgNKU1l2C5/Ht7gG2iDEBxYnNUvVAMQprTHYt5T1qTwn8uaT+Lw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-runtime": "^1.2.5",
-        "@fluidframework/container-utils": "^1.2.5",
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/datastore": "^1.2.5",
-        "@fluidframework/datastore-definitions": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-runtime": "^1.3.6",
+        "@fluidframework/container-utils": "^1.3.6",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/datastore": "^1.3.6",
+        "@fluidframework/datastore-definitions": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/runtime-definitions": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/telemetry-utils": "^1.2.5",
+        "@fluidframework/runtime-definitions": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/telemetry-utils": "^1.3.6",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -1445,17 +2405,17 @@
       }
     },
     "@fluidframework/synthesize": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.5.tgz",
-      "integrity": "sha512-ZlipWxIdZa09cR3hOshh9WNgFk3vbaksnQq4ihsdCTYJrHh9S+chKSIVkgd/7KVgHAr+gEMOicgQBBfMTk7sug=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.3.6.tgz",
+      "integrity": "sha512-avt0K5uxvOjs1Y6XpisonkMmG3RaI901h5XfIWFlxOhkHSgeN7T3ZmTdAinlpyRv+XKHzVzN1SqaccpGeC0+lw=="
     },
     "@fluidframework/telemetry-utils": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.5.tgz",
-      "integrity": "sha512-red4y9zabiYDeHqMEwnMkFuw/mW2rKI2TbiSUDAuPC8hiZp+T8ovF/GXp/mB1XzXbBJ2ZnW9+IMV0OcM5pib0A==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.3.6.tgz",
+      "integrity": "sha512-9DoLzKwnELWBN2NiCJPgfj2lCER4IiHSgiBMwbLoEZ0qTqGKhWJ1+7m1PupuwGuKX1zbb9HjUNxv2ommokZcqw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
+        "@fluidframework/common-utils": "^0.32.2",
         "debug": "^4.1.1",
         "events": "^3.1.0",
         "uuid": "^8.3.1"
@@ -1469,22 +2429,22 @@
       }
     },
     "@fluidframework/tinylicious-client": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.2.5.tgz",
-      "integrity": "sha512-hO3vfgaQHUX48bpgJX/MB9W1WMhO1bAPNBT9tb4OKl6PRD84U5LvDI83Y4OE+crpmngmLXroowpsibMsFXk8SA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-1.3.6.tgz",
+      "integrity": "sha512-I4qOOFbKavCmWhBh/RnBBqFVQPm56B/HESremvunm5MKRKoeewyfe91d3L8Dq1RTn2krPnR6nojyz3NV55/eyQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.32.1",
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-loader": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
-        "@fluidframework/fluid-static": "^1.2.5",
-        "@fluidframework/map": "^1.2.5",
+        "@fluidframework/common-utils": "^0.32.2",
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-loader": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
+        "@fluidframework/fluid-static": "^1.3.6",
+        "@fluidframework/map": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/routerlicious-driver": "^1.2.5",
-        "@fluidframework/runtime-utils": "^1.2.5",
-        "@fluidframework/tinylicious-driver": "^1.2.5",
+        "@fluidframework/routerlicious-driver": "^1.3.6",
+        "@fluidframework/runtime-utils": "^1.3.6",
+        "@fluidframework/tinylicious-driver": "^1.3.6",
         "uuid": "^8.3.1"
       },
       "dependencies": {
@@ -1496,16 +2456,16 @@
       }
     },
     "@fluidframework/tinylicious-driver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.2.5.tgz",
-      "integrity": "sha512-MNjCv2q9n+R19u5on9TqfpMERi8ePhmhGjQflyh0+iiM/uSUNHVI/y/RPWpAipcwMMFt91ZkftJf/HhsFWEInw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-1.3.6.tgz",
+      "integrity": "sha512-ZV6HZ1Lxnl0WFX6ajg0vpG5bCpMK21cUSI7QHteyXR76APqodu3HnMksEIuA1IgxCAW/o5n/eN02hY36yz8ANg==",
       "requires": {
-        "@fluidframework/core-interfaces": "^1.2.5",
-        "@fluidframework/driver-definitions": "^1.2.5",
-        "@fluidframework/driver-utils": "^1.2.5",
+        "@fluidframework/core-interfaces": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/driver-utils": "^1.3.6",
         "@fluidframework/protocol-definitions": "^0.1028.2000",
-        "@fluidframework/routerlicious-driver": "^1.2.5",
-        "@fluidframework/server-services-client": "^0.1036.5000",
+        "@fluidframework/routerlicious-driver": "^1.3.6",
+        "@fluidframework/server-services-client": "^0.1036.5001",
         "jsrsasign": "^10.5.25",
         "uuid": "^8.3.1"
       },
@@ -1518,11 +2478,11 @@
       }
     },
     "@fluidframework/view-interfaces": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.5.tgz",
-      "integrity": "sha512-oPJCn4TD0B0raX4Dl6+3Z9zoX13v2cJligwKENGoKvSOsYpszD1Dh59eTTtMHRGv7aY4LHjZbS30Mersn+cr8w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.3.6.tgz",
+      "integrity": "sha512-QEBEPmJdNCO7BdCjUaFxA32fjH91LePRs2xMV5iK8KRQwkyYnp4kRa3nKD3Iv2ezYKG+MvtAIDmUvfzICwWxUA==",
       "requires": {
-        "@fluidframework/core-interfaces": "^1.2.5"
+        "@fluidframework/core-interfaces": "^1.3.6"
       }
     },
     "@hapi/address": {
@@ -2257,6 +3217,26 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
+    "@socket.io/redis-adapter": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-7.2.0.tgz",
+      "integrity": "sha512-/r6oF6Myz0K9uatB/pfCi0BhKg/KRMh1OokrqcjlNz6aq40WiXdFLRbHJQuwGHq/KvB+D6141K+IynbVxZGvhw==",
+      "dev": true,
+      "requires": {
+        "debug": "~4.3.1",
+        "notepack.io": "~2.2.0",
+        "socket.io-adapter": "^2.4.0",
+        "uid2": "0.0.3"
+      },
+      "dependencies": {
+        "notepack.io": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.2.0.tgz",
+          "integrity": "sha512-9b5w3t5VSH6ZPosoYnyDONnUTF8o0UkBw7JLA6eBlYJWyGT1Q3vQa8Hmuj1/X6RYvHjjygBDgw6fJhe0JEojfw==",
+          "dev": true
+        }
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2303,6 +3283,36 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+      "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/double-ended-queue": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.2.tgz",
+      "integrity": "sha512-iAjbBa3X4UQtYxcCsAr0YaZMRwyC79q4KHui0XtEN7GGLJA4fzD116KUYXXZKskaOYSchnaOFT/a8zSlEx3P9Q==",
+      "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
@@ -2358,10 +3368,28 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.192",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
+      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
+    "@types/nconf": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.3.tgz",
+      "integrity": "sha512-leyIuBk/rMIp9114FlPRkc/cQG+/JzCz1Afx3BD+CwK2ep3ZRxoC843V1rqnE2pC/jRRjANWhuVBEn4clCwlug==",
       "dev": true
     },
     "@types/node": {
@@ -2382,6 +3410,12 @@
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz",
+      "integrity": "sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==",
+      "dev": true
+    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -2398,6 +3432,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
+      "dev": true
+    },
+    "@types/triple-beam": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
+      "integrity": "sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -2440,6 +3480,15 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "@types/ws": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/yargs": {
@@ -2686,6 +3735,39 @@
         "event-target-shim": "^5.0.0"
       }
     },
+    "abstract-level": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
+      "dev": true,
+      "requires": {
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        }
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -2726,6 +3808,12 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "address": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2733,6 +3821,25 @@
       "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.3.0.tgz",
+      "integrity": "sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^2.0.0",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -2846,6 +3953,12 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -2956,6 +4069,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
+    "async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2966,6 +4085,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
     "aws-sign2": {
@@ -3198,6 +4323,29 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -3362,6 +4510,18 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dev": true,
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -3500,6 +4660,12 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3529,6 +4695,25 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
+    },
+    "bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "dev": true,
+      "requires": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "dev": true,
+      "requires": {
+        "typewise-core": "^1.2"
+      }
     },
     "cacache": {
       "version": "12.0.4",
@@ -3631,6 +4816,12 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+    "catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3657,6 +4848,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
+    "charwise": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+      "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw==",
       "dev": true
     },
     "check-more-types": {
@@ -3778,6 +4975,19 @@
         }
       }
     },
+    "classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "dev": true,
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "clean-css": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
@@ -3786,6 +4996,12 @@
       "requires": {
         "source-map": "~0.6.0"
       }
+    },
+    "clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+      "dev": true
     },
     "clean-webpack-plugin": {
       "version": "3.0.0",
@@ -3819,6 +5035,12 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "dev": true
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3841,6 +5063,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3856,11 +5088,31 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dev": true,
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4024,6 +5276,24 @@
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
     },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dev": true,
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4060,6 +5330,16 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "crc-32": {
       "version": "1.2.0",
@@ -4308,6 +5588,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -4489,6 +5778,12 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4523,10 +5818,26 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "detect-port": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
+      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+      "dev": true,
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "4"
+      }
+    },
     "diff-sequences": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+      "dev": true
+    },
+    "diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
       "dev": true
     },
     "diffie-hellman": {
@@ -4693,6 +6004,15 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -4746,6 +6066,12 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
     },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -4761,15 +6087,47 @@
         "once": "^1.4.0"
       }
     },
+    "engine.io": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.1.tgz",
+      "integrity": "sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==",
+      "dev": true,
+      "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.11.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "dev": true
+        }
+      }
+    },
     "engine.io-client": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
-      "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
+      "integrity": "sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.0.3",
-        "ws": "~8.2.3",
+        "ws": "~8.11.0",
         "xmlhttprequest-ssl": "~2.0.0"
       }
     },
@@ -4888,6 +6246,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "dev": true
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -5418,6 +6782,12 @@
         "pend": "~1.2.0"
       }
     },
+    "fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -5604,374 +6974,16 @@
       }
     },
     "fluid-framework": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.2.5.tgz",
-      "integrity": "sha512-pYSi7gqEzfnV23+lKbrp3uUzPxAr8O8s52+enW6MskYeRq/w6aNaPN0LgorwLk0+GN+ZMvtEGDFjTt4zwe2Gfw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-1.3.6.tgz",
+      "integrity": "sha512-RW+yqWitqAQgX1GsY9pynUEHtQm7Yw5em9BDj29LAzBtLonS4dmqW146qLLD9IJAbF31EfSyBlvLyWHqdqhI6w==",
       "requires": {
-        "@fluidframework/container-definitions": "^1.2.5",
-        "@fluidframework/container-loader": "^1.2.5",
-        "@fluidframework/fluid-static": "^1.2.5",
-        "@fluidframework/map": "^1.2.5",
-        "@fluidframework/sequence": "^1.2.5"
-      },
-      "dependencies": {
-        "@fluidframework/aqueduct": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-1.2.5.tgz",
-          "integrity": "sha512-9wpP2xmOdrGsgAnc/ZgX9JnxqYv9SHC8ubauhTa0lHlWYdyvJVu+gO+reVNVkHSGq7DQZl4Sg5j4ly8mAs1o1A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-loader": "^1.2.5",
-            "@fluidframework/container-runtime": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/map": "^1.2.5",
-            "@fluidframework/request-handler": "^1.2.5",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/synthesize": "^1.2.5",
-            "@fluidframework/view-interfaces": "^1.2.5",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/container-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-1.2.5.tgz",
-          "integrity": "sha512-11prpsstqz32XkO4Iy828hS2VpJE5Nv+h54GA9uLpbeUjMHe8tBxaYsXjTmAvV9954iomtk3KBzBv7x3da969g==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/container-loader": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-1.2.5.tgz",
-          "integrity": "sha512-uxemA6EbF5jnAFEU+8flBgkASMi4IdlQAwX1idIjJlBGlJ6la/u1YwFlLXFFOL6zo4l92PFK9O/or7VHNdXHGQ==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "abort-controller": "^3.0.0",
-            "double-ended-queue": "^2.1.0-0",
-            "lodash": "^4.17.21",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/container-runtime": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-1.2.5.tgz",
-          "integrity": "sha512-sa/RRhG3v5zYNxWWrp7mnDrLrh+AJqgvQGUnXijZaxpktB0THoXbSJezji7wym8uzmCIkbOB6P1Kxgu6ktdoAA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "double-ended-queue": "^2.1.0-0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/container-runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-+TJk0o8fU8dZmYmb33Dv6ZLWUQhZzB/aWdBWoZagekSxT/upaDP21WoxkPJ9CWHZvp3GvFTfvMWKlUoq1gMW8A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/container-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-1.2.5.tgz",
-          "integrity": "sha512-ZMQwYMCjv253nN7QvouRhOk1nr5NEyR/HBeeyOePdlp/LJ9qCKZb1kwOgirPr401J6crm+ZlKaE3HNnLcRcx6Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/core-interfaces": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-1.2.5.tgz",
-          "integrity": "sha512-ANv7NpLQPTzYBZK9b7CbkxDI62MTFN51Zs/qkwWKOYFfTqOiCEHGM3/tU2+0xoH3VaQboNIJW9HxPvIko3PJkA=="
-        },
-        "@fluidframework/datastore": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-1.2.5.tgz",
-          "integrity": "sha512-29TQ+gvl3b0s10CbwHZTw+SJ34DfpFHhnNsPTWQpglXosBJZWRS2gM7nsoS5XDfvG241eLmaWaOMc4xo1jXCgw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "lodash": "^4.17.21",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/datastore-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-1.2.5.tgz",
-          "integrity": "sha512-zgTMPgYpOakQ1S0jaPL7dUzFGJFxI56hvPYQzrHE70m5926zqMJvdDEhoTK+pj8opKbol8NDC0iZVRtR0/Pwhw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/driver-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-1.2.5.tgz",
-          "integrity": "sha512-cSExTm0mWBz0I6NnUyIAuYJDiHqMY4Jg8Up8VYevfdaCnbUVNRSxUC806PL81KtGxgaCDUVf1NVGG6Ao6GsJAg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000"
-          }
-        },
-        "@fluidframework/driver-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-1.2.5.tgz",
-          "integrity": "sha512-AvDkUMbFV2Se+TaSmL/9lGop9ZNV7yESDxYNj4uU6KNB+OPrvcctX4kdNACZQuUIUXAobYIVK/mQirh3qSSufg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "axios": "^0.26.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/fluid-static": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-1.2.5.tgz",
-          "integrity": "sha512-hI7WM/9NjhSMSYAvAOh+WxuQ9FCzq+qQ54p58NkYKuHwo1eQ36CVfQyTUjh5VXsO7ubSvKCKAlbuqRHXBI0eIQ==",
-          "requires": {
-            "@fluidframework/aqueduct": "^1.2.5",
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-loader": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/request-handler": "^1.2.5",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/garbage-collector": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-1.2.5.tgz",
-          "integrity": "sha512-lTSStL2tJGnigFs09o/bUrEC+7SfZXVXF4tIVfcXPQ1yNSDofzWDLdovA7OLuKUIdMVKXgdNSVohHprgpAbuKw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/runtime-definitions": "^1.2.5"
-          }
-        },
-        "@fluidframework/gitresources": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1036.5000.tgz",
-          "integrity": "sha512-Aq030GDRhPJCr7tVHDxFtWDwc6nd1r9x7k0/D34mVAVuXLyubk5dB2BytopZxfo9b91QXIPmjQfQ2GINTdk16w=="
-        },
-        "@fluidframework/map": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-1.2.5.tgz",
-          "integrity": "sha512-MDKsQarfwCwujEba2/4bJqp+LwKUWPaB20zK2FRXLO09Vq11Anu/0yhker94UpiSGmEaXjJ0GZ3vpdXRy2Pukg==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/driver-utils": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/shared-object-base": "^1.2.5",
-            "path-browserify": "^1.0.1"
-          }
-        },
-        "@fluidframework/protocol-base": {
-          "version": "0.1036.5000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1036.5000.tgz",
-          "integrity": "sha512-tsDtM6jptTwbqkVtqO6KRYRu6614ZwrzfJJEUM0OmTRk6ds5vdA+vPreG4qrrEO40HHy4y9nHx6AyGL/sMxv4w==",
-          "requires": {
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/gitresources": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "lodash": "^4.17.21"
-          }
-        },
-        "@fluidframework/protocol-definitions": {
-          "version": "0.1028.2000",
-          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-0.1028.2000.tgz",
-          "integrity": "sha512-ZUPCmPFcK7UAK4RkfVWfzQPAWFvYNm6ywP51V42YC38gCGye+Epvyr3beA+FSaHPIZGxm5+Uw52+ykTvmDb2UA==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1"
-          }
-        },
-        "@fluidframework/request-handler": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-1.2.5.tgz",
-          "integrity": "sha512-ua/ssLobf+1wEAlZyEvQcbGbTxtZXFBDZtnjeYKilY47NDt1gV99dIpKRZrLs8yFyTNHGXEXD9hv8w6OOqfQmQ==",
-          "requires": {
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/runtime-definitions": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-1.2.5.tgz",
-          "integrity": "sha512-j38odkSWNy4MSFGY7HWbxUm/GSD/V7DCDoxtE1ohieswyLyeHLZTCf7IxQuOZk1exbxSOUYJg/89yxFEWSpTvw==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/driver-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@types/node": "^14.18.0"
-          }
-        },
-        "@fluidframework/runtime-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-1.2.5.tgz",
-          "integrity": "sha512-RVjI6AvXXwmQ0MbtF22qgre/OnV5ul3kQOcBjBWm2ZikkqyEwdpSzLQhqRMVToJDUrZ4RTinox/qQlSBr3qtbQ==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime-definitions": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/garbage-collector": "^1.2.5",
-            "@fluidframework/protocol-base": "^0.1036.5000",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5"
-          }
-        },
-        "@fluidframework/shared-object-base": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-1.2.5.tgz",
-          "integrity": "sha512-dnrfl1pYGh5Pe19XWkdz2wYRmX92pw6kpwZ0zFxEvGryWLZXcd4MWqljknTBPMwBxeKj7+8RiLN9E6iJFC4n4Q==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "@fluidframework/container-definitions": "^1.2.5",
-            "@fluidframework/container-runtime": "^1.2.5",
-            "@fluidframework/container-utils": "^1.2.5",
-            "@fluidframework/core-interfaces": "^1.2.5",
-            "@fluidframework/datastore": "^1.2.5",
-            "@fluidframework/datastore-definitions": "^1.2.5",
-            "@fluidframework/protocol-definitions": "^0.1028.2000",
-            "@fluidframework/runtime-definitions": "^1.2.5",
-            "@fluidframework/runtime-utils": "^1.2.5",
-            "@fluidframework/telemetry-utils": "^1.2.5",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/synthesize": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-1.2.5.tgz",
-          "integrity": "sha512-ZlipWxIdZa09cR3hOshh9WNgFk3vbaksnQq4ihsdCTYJrHh9S+chKSIVkgd/7KVgHAr+gEMOicgQBBfMTk7sug=="
-        },
-        "@fluidframework/telemetry-utils": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-1.2.5.tgz",
-          "integrity": "sha512-red4y9zabiYDeHqMEwnMkFuw/mW2rKI2TbiSUDAuPC8hiZp+T8ovF/GXp/mB1XzXbBJ2ZnW9+IMV0OcM5pib0A==",
-          "requires": {
-            "@fluidframework/common-definitions": "^0.20.1",
-            "@fluidframework/common-utils": "^0.32.1",
-            "debug": "^4.1.1",
-            "events": "^3.1.0",
-            "uuid": "^8.3.1"
-          }
-        },
-        "@fluidframework/view-interfaces": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-1.2.5.tgz",
-          "integrity": "sha512-oPJCn4TD0B0raX4Dl6+3Z9zoX13v2cJligwKENGoKvSOsYpszD1Dh59eTTtMHRGv7aY4LHjZbS30Mersn+cr8w==",
-          "requires": {
-            "@fluidframework/core-interfaces": "^1.2.5"
-          }
-        },
-        "@types/node": {
-          "version": "14.18.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.29.tgz",
-          "integrity": "sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A=="
-        },
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.15.2",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@fluidframework/container-definitions": "^1.3.6",
+        "@fluidframework/container-loader": "^1.3.6",
+        "@fluidframework/driver-definitions": "^1.3.6",
+        "@fluidframework/fluid-static": "^1.3.6",
+        "@fluidframework/map": "^1.3.6",
+        "@fluidframework/sequence": "^1.3.6"
       }
     },
     "flush-write-stream": {
@@ -5984,11 +6996,26 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.3.tgz",
       "integrity": "sha512-3MkHxknWMUtb23apkgz/83fDoe+y+qr0TdgacGIA7bew+QLBo3vdgEN2xEsuXNivpFy4CyDhBBZnNZOtalmenw==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -6245,6 +7272,34 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "dependencies": {
+        "get-intrinsic": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+          "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
           "dev": true
         }
       }
@@ -6594,6 +7649,15 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -6606,13 +7670,18 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "import-local": {
@@ -6727,6 +7796,25 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "ioredis": {
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.28.5.tgz",
+      "integrity": "sha512-3GYo0GJtLqgNXj4YhrisLaNNvWSNwSS2wS4OELGfGxH8I69+XfNdnmV1AyN+ZqMh0i7eX+SWjrwFKDBDgfBC1A==",
+      "dev": true,
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      }
     },
     "ip": {
       "version": "1.1.5",
@@ -6926,6 +8014,15 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -6933,6 +8030,16 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "is-negative-zero": {
@@ -7043,6 +8150,19 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -7070,6 +8190,38 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-git": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.23.0.tgz",
+      "integrity": "sha512-7mQlnZivFwrU6B3CswvmoNtVN8jqF9BcLf80uk7yh4fNA8PhFjAfQigi2Hu/Io0cmIvpOc7vn0/Rq3KtL5Ph8g==",
+      "dev": true,
+      "requires": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -9083,6 +10235,44 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dev": true,
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -9099,6 +10289,27 @@
       "version": "10.5.27",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.27.tgz",
       "integrity": "sha512-1F4LmDeJZHYwoVvB44jEo2uZL3XuwYNzXCDOu53Ui6vqofGQ/gCYDmaxfVZtN0TGd92UKXr/BONcfrPonUIcQQ=="
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dev": true,
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "jwt-decode": {
       "version": "3.1.2",
@@ -9123,6 +10334,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true
+    },
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -9134,6 +10351,112 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
       "dev": true
+    },
+    "level": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
+      "dev": true,
+      "requires": {
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
+      }
+    },
+    "level-codec": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
+    "level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+      "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5",
+        "xtend": "^4.0.0"
+      }
+    },
+    "level-post": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+      "dev": true,
+      "requires": {
+        "ltgt": "^2.1.2"
+      }
+    },
+    "level-sublevel": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.4.tgz",
+      "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
+      "dev": true,
+      "requires": {
+        "bytewise": "~1.1.0",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0",
+        "level-iterator-stream": "^2.0.3",
+        "ltgt": "~2.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-level": "^2.0.3",
+        "pull-stream": "^3.6.8",
+        "typewiselite": "~1.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
+    "level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true
+    },
+    "level-transcoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -9189,10 +10512,48 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
+    },
+    "logform": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.5.1.tgz",
+      "integrity": "sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==",
+      "dev": true,
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
     "loglevel": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
+      "dev": true
+    },
+    "looper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+      "integrity": "sha512-6DzMHJcjbQX/UPHc1rRCBfKlLwDkvuGZ715cIR36wSdYqWXFT35uLXq5P/2orl3tz+t+VOVPxw4yPinQlUDGDQ==",
       "dev": true
     },
     "lower-case": {
@@ -9220,6 +10581,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "ltgt": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+      "integrity": "sha512-5VjHC5GsENtIi5rbJd+feEpDKhfr7j0odoUR2Uh978g+2p93nd5o34cTjQWohXsPsCZeqoDnIqEf88mPCe0Pfw==",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",
@@ -9436,6 +10803,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -9462,6 +10835,15 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "mississippi": {
       "version": "3.0.0",
@@ -9529,6 +10911,48 @@
         "minimist": "^1.2.5"
       }
     },
+    "module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -9590,11 +11014,154 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "nconf": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+      "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
+      "dev": true,
+      "requires": {
+        "async": "^3.0.0",
+        "ini": "^2.0.0",
+        "secure-keys": "^1.0.0",
+        "yargs": "^16.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "ini": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -9644,6 +11211,12 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "dev": true
     },
     "node-int64": {
@@ -9780,6 +11353,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "notepack.io": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.3.0.tgz",
+      "integrity": "sha512-9RiFDxeydHsWOqdthRUck2Kd4UW2NzVd2xxOulZiQ9mvge6ElsHXLpwD3HEJyql6sFEnEn/eMO7HSdS0M5mWkA==",
       "dev": true
     },
     "npm-run-path": {
@@ -9940,6 +11519,15 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -10463,6 +12051,64 @@
         }
       }
     },
+    "pull-cat": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+      "integrity": "sha512-i3w+xZ3DCtTVz8S62hBOuNLRHqVDsHMNZmgrZsjPnsxXUgbWtXEee84lo1XswE7W2a3WHyqsNuDJTjVLAQR8xg==",
+      "dev": true
+    },
+    "pull-defer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
+      "dev": true
+    },
+    "pull-level": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+      "dev": true,
+      "requires": {
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
+      }
+    },
+    "pull-live": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+      "integrity": "sha512-tkNz1QT5gId8aPhV5+dmwoIiA1nmfDOzJDlOOUpU5DNusj6neNd3EePybJ5+sITr2FwyCs/FVpx74YMCfc8YeA==",
+      "dev": true,
+      "requires": {
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
+      }
+    },
+    "pull-pushable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha512-M7dp95enQ2kaHvfCt2+DJfyzgCSpWVR2h2kWYnVsW6ZpxQBx5wOu0QWOvQPVoPnBLUZYitYP2y7HyHkLQNeGXg==",
+      "dev": true
+    },
+    "pull-stream": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.7.0.tgz",
+      "integrity": "sha512-Eco+/R004UaCK2qEDE8vGklcTG2OeZSVm1kTUQNrykEjDwcFXDZhygFDsW49DbXyJMEhHeRL3z5cRVqPAhXlIw==",
+      "dev": true
+    },
+    "pull-window": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+      "integrity": "sha512-cbDzN76BMlcGG46OImrgpkMf/VkCnupj8JhsrpBw3aWBM9ye345aYnqitmZCgauBkc0HbbRRn9hCnsa3k2FNUg==",
+      "dev": true,
+      "requires": {
+        "looper": "^2.0.0"
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -10586,6 +12232,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10791,6 +12443,27 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
+      "dev": true
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regex-not": {
@@ -11019,6 +12692,15 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
+    "run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -11056,6 +12738,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -11188,6 +12876,12 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "secure-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+      "integrity": "sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==",
+      "dev": true
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -11251,6 +12945,23 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -11434,6 +13145,40 @@
       "resolved": "https://registry.npmjs.org/sillyname/-/sillyname-0.1.0.tgz",
       "integrity": "sha512-GWA0Zont13ov+cMNw4T7nU4SCyW8jdhD3vjA5+qs8jr+09sCPxOf+FPS5zE0c9pYlCwD+NU/CiMimY462lgG9g=="
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11580,15 +13325,46 @@
         }
       }
     },
+    "socket.io": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.2",
+        "engine.io": "~6.4.1",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.1"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+      "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
+      "dev": true,
+      "requires": {
+        "ws": "~8.11.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+          "dev": true
+        }
+      }
+    },
     "socket.io-client": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.2.tgz",
-      "integrity": "sha512-naqYfFu7CLDiQ1B7AlLhRXKX3gdeaIMfgigwavDzgJoIUYulc1qHH5+2XflTsXTPY7BlPH5rppJyUjhjrKQKLg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.6.1.tgz",
+      "integrity": "sha512-5UswCV6hpaRsNg5kkEHVcbBIXEYoVbMQaHJBXJCyEQ+CiFPV1NIOY0XOFWG4XR4GZcB8Kn6AsRs/9cy9TbqVMQ==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.2.1",
-        "socket.io-parser": "~4.2.0"
+        "engine.io-client": "~6.4.0",
+        "socket.io-parser": "~4.2.1"
       }
     },
     "socket.io-parser": {
@@ -11781,6 +13557,12 @@
         "figgy-pudding": "^3.5.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -11797,6 +13579,12 @@
           "dev": true
         }
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true
     },
     "start-server-and-test": {
       "version": "1.14.0",
@@ -11962,6 +13750,30 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
+    },
+    "stream-to-pull-stream": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+      "dev": true,
+      "requires": {
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
+      },
+      "dependencies": {
+        "looper": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+          "integrity": "sha512-LJ9wplN/uSn72oJRsXTx+snxPet5c8XiZmOKCm906NVYu+ag6SB6vUcnJcWxgnl2NfbIyeobAn7Bwv6xRj2XJg==",
+          "dev": true
+        }
+      }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "dev": true
     },
     "string-length": {
@@ -12143,6 +13955,12 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true
+    },
     "throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -12216,6 +14034,153 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tinylicious": {
+      "version": "0.4.94771",
+      "resolved": "https://registry.npmjs.org/tinylicious/-/tinylicious-0.4.94771.tgz",
+      "integrity": "sha512-Kde8XznxOaYLkfJLQdwNlJbz2ejJtqaYAWyiG2pdQ1O97nV5rDYVKtPub7+MC4hDWQ/9pqsxNRdpzeAjU097Ng==",
+      "dev": true,
+      "requires": {
+        "@fluidframework/common-utils": "^1.0.0",
+        "@fluidframework/gitresources": "^0.1038.1000",
+        "@fluidframework/protocol-base": "^0.1038.1000",
+        "@fluidframework/protocol-definitions": "^1.0.0",
+        "@fluidframework/server-lambdas": "^0.1038.1000",
+        "@fluidframework/server-local-server": "^0.1038.1000",
+        "@fluidframework/server-memory-orderer": "^0.1038.1000",
+        "@fluidframework/server-services-client": "^0.1038.1000",
+        "@fluidframework/server-services-core": "^0.1038.1000",
+        "@fluidframework/server-services-shared": "^0.1038.1000",
+        "@fluidframework/server-services-telemetry": "^0.1038.1000",
+        "@fluidframework/server-services-utils": "^0.1038.1000",
+        "@fluidframework/server-test-utils": "^0.1038.1000",
+        "agentkeepalive": "^4.2.1",
+        "axios": "^0.26.0",
+        "body-parser": "^1.17.1",
+        "charwise": "^3.0.1",
+        "compression": "^1.7.2",
+        "cookie-parser": "^1.4.3",
+        "cors": "^2.8.4",
+        "detect-port": "^1.3.0",
+        "express": "^4.16.3",
+        "isomorphic-git": "^1.8.2",
+        "json-stringify-safe": "^5.0.1",
+        "level": "^8.0.0",
+        "level-sublevel": "6.6.4",
+        "lodash": "^4.17.21",
+        "morgan": "^1.8.1",
+        "nconf": "^0.12.0",
+        "socket.io": "^4.5.0",
+        "split": "^1.0.0",
+        "uuid": "^8.3.2",
+        "winston": "^3.6.0"
+      },
+      "dependencies": {
+        "@fluidframework/common-utils": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@fluidframework/common-utils/-/common-utils-1.1.1.tgz",
+          "integrity": "sha512-XCPEFE1JAg+juQZYQQVZjHZJlM5+Wm9NxRbsnsix05M1tSq0p3SLqwgfaSGssXhLLX5QtG+aF1QD5a3LA1qtNQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@types/events": "^3.0.0",
+            "base64-js": "^1.5.1",
+            "buffer": "^6.0.3",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21",
+            "sha.js": "^2.4.11"
+          }
+        },
+        "@fluidframework/gitresources": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1038.4001.tgz",
+          "integrity": "sha512-6AWxkiTpXy4JbDKAAOyG0CzLb0h+N2+Z05U/ap9UzuFuoLPMGM4XRewQhfrhXQx/cbEi0gXC6yWY2SIOrp94hQ==",
+          "dev": true
+        },
+        "@fluidframework/protocol-base": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1038.4001.tgz",
+          "integrity": "sha512-tTY95a8iYqt+wXxbKeDuHUxSJBWGmLmXEQNS2rnw98Oo8qAX95nucTRG6pK+qCXE48MUbPoKK3gEOkWo3Eu4Tg==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "events": "^3.1.0",
+            "lodash": "^4.17.21"
+          }
+        },
+        "@fluidframework/protocol-definitions": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/protocol-definitions/-/protocol-definitions-1.1.0.tgz",
+          "integrity": "sha512-Q4YA6FBlB2cHicgvfs9z3LPKnfZMdx5JrmIEGOmxFmom/l9EV1F43sXl6K9/j5se8tQ9V9L8drFbDzqVf37roQ==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1038.4001",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1038.4001.tgz",
+          "integrity": "sha512-V9ma67bvIS0G6fYGgHqcxazEZnKBajTjz13WaygUn4nhcfxAbQwl6bfyNFyD3JV910PVTFEdP2sNKjmvURfWoA==",
+          "dev": true,
+          "requires": {
+            "@fluidframework/common-utils": "^1.1.1",
+            "@fluidframework/gitresources": "^0.1038.4001",
+            "@fluidframework/protocol-base": "^0.1038.4001",
+            "@fluidframework/protocol-definitions": "^1.1.0",
+            "axios": "^0.26.0",
+            "crc-32": "1.2.0",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "^5.0.1",
+            "jsrsasign": "^10.5.25",
+            "jwt-decode": "^3.0.0",
+            "querystring": "^0.2.0",
+            "sillyname": "^0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+          "dev": true
+        },
+        "split": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+          "dev": true,
+          "requires": {
+            "through": "2"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "tmpl": {
@@ -12332,6 +14297,12 @@
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -12403,6 +14374,33 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "dev": true,
+      "requires": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "dev": true
+    },
+    "typewiselite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+      "integrity": "sha512-J9alhjVHupW3Wfz6qFRGgQw0N3gr8hOkw6zm7FZ6UR1Cse/oD9/JVok7DNE9TT9IbciDHX2Ex9+ksE6cRmtymw==",
+      "dev": true
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha512-5gSP1liv10Gjp8cMEnFd6shzkL/D6W1uhXSFNCxDC+YI8+L8wkCYCbJ7n77Ezb4wE/xzMogecE+DtamEe9PZjg==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -12539,7 +14537,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -12548,8 +14545,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },
@@ -13525,11 +15521,87 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
+    },
     "wildcard": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
       "dev": true
+    },
+    "winston": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz",
+      "integrity": "sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==",
+      "dev": true,
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
+      "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
+      "dev": true,
+      "requires": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",
@@ -13576,9 +15648,9 @@
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:dev": "webpack --env clean",
     "start": "start-server-and-test start:server 7070 start:client",
     "start:client": "webpack serve",
-    "start:server": "npx tinylicious@latest",
+    "start:server": "tinylicious",
     "format": "npm run prettier:fix",
     "lint": "npm run prettier",
     "lint:fix": "npm run prettier:fix",
@@ -19,8 +19,8 @@
     "test": "start-server-and-test start:server 7070 jest"
   },
   "dependencies": {
-    "@fluidframework/tinylicious-client": "^1.2.5",
-    "fluid-framework": "^1.2.5"
+    "@fluidframework/tinylicious-client": "^1.3.6",
+    "fluid-framework": "^1.3.6"
   },
   "devDependencies": {
     "@fluidframework/build-common": "^1.0.0",
@@ -34,6 +34,7 @@
     "webpack-dev-server": "^3.11.0",
     "jest": "^26.6.3",
     "jest-puppeteer": "^4.3.0",
-    "puppeteer": "^1.20.0"
+    "puppeteer": "^1.20.0",
+    "tinylicious": "^0.4.0"
   }
 }


### PR DESCRIPTION
I bumped the fluid deps to the latest and added a devDep on tinylicious so we can pin it, and also avoid the download which slows things down when using npx.