### PR TITLE
docs: Add explicit note with URL for running the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ After cloning the repository, install dependencies and start the application
 npm install
 npm start
 ```
+
+Navigate to `localhost:8080` in the browser to view the app.


### PR DESCRIPTION
Since `npm start` does not launch the browser, this should hopefully help avoid some confusion for first-time users.