### PR TITLE
Updates pipeline build to new M365 template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ extends:
           serviceConnection: Arrow_FluidFramework_internal
         ${{ else }}:
           serviceConnection: Arrow_FluidFramework_public
+      settings:
+        skipBuildTagsForGitHubPullRequests: true 
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ extends:
   template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: Small-linux-1ES
+      name: Small-1ES
       os: linux
     sdl:
       arrow:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ pr:
   - main
   - main-azure
 
+# The `resources` specify the location and version of the 1ES PT.
 resources:
   repositories:
     - repository: m365Pipelines
@@ -15,10 +16,12 @@ resources:
       ref: refs/tags/release
 
 extends:
+  # The pipeline extends the 1ES PT which will inject different SDL and compliance tasks.
+  # Read more: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview
   template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: Small-1ES
+      name: Small-1ES # This is one of the Fluid Orgs new 1ES hosted pools.
       os: linux
     sdl:
       arrow:
@@ -37,9 +40,9 @@ extends:
     customBuildTags:
       - ES365AIMigrationTooling
     stages:
-      - stage: stage
+      - stage: Run_build
         jobs:
-          - job: job
+          - job: Run_build
             steps:
               - task: ComponentGovernanceComponentDetection@0
                 inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ extends:
         ${{ else }}:
           serviceConnection: Arrow_FluidFramework_public
       settings:
-        skipBuildTagsForGitHubPullRequests: 'true'
+        skipBuildTagsForGitHubPullRequests: "true"
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ extends:
         ${{ else }}:
           serviceConnection: Arrow_FluidFramework_public
       settings:
-        skipBuildTagsForGitHubPullRequests: true 
+        skipBuildTagsForGitHubPullRequests: 'true'
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,17 +6,19 @@
 pr:
   - main
   - main-azure
+
 resources:
   repositories:
     - repository: m365Pipelines
       type: git
       name: 1ESPipelineTemplates/M365GPT
       ref: refs/tags/release
+
 extends:
   template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
-      name: NewLarge-linux-1ES
+      name: Small-linux-1ES
       os: linux
     sdl:
       arrow:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,40 +6,67 @@
 pr:
   - main
   - main-azure
-
-pool: "Small"
-
-steps:
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      scanType: "Register"
-      verbosity: "Verbose"
-      alertWarningLevel: "High"
-  - task: UseNode@1
-    displayName: Use Node 18.x
-    inputs:
-      version: 18.x
-  - task: Npm@1
-    displayName: Install
-    inputs:
-      command: "custom"
-      customCommand: "ci"
-  - task: CmdLine@2
-    displayName: Build
-    inputs:
-      script: "npm run build"
-  - task: CmdLine@2
-    displayName: Lint
-    inputs:
-      script: "npm run lint"
-  - task: CmdLine@2
-    displayName: Test
-    inputs:
-      script: "npm run ci:test"
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    inputs:
-      testResultsFormat: "JUnit"
-      testResultsFiles: "**/*junit-report.xml"
-      searchFolder: "$(System.DefaultWorkingDirectory)"
-    condition: succeededOrFailed()
+resources:
+  repositories:
+    - repository: m365Pipelines
+      type: git
+      name: 1ESPipelineTemplates/M365GPT
+      ref: refs/tags/release
+extends:
+  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  parameters:
+    pool:
+      name: NewLarge-linux-1ES
+      os: linux
+    sdl:
+      arrow:
+        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
+        # Currently we want to use different names for internal and public builds for Arrow Service Connection
+        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          serviceConnection: Arrow_FluidFramework_internal
+        ${{ else }}:
+          serviceConnection: Arrow_FluidFramework_public
+      sourceAnalysisPool:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-2022
+        os: windows
+    customBuildTags:
+      - ES365AIMigrationTooling
+    stages:
+      - stage: stage
+        jobs:
+          - job: job
+            steps:
+              - task: ComponentGovernanceComponentDetection@0
+                inputs:
+                  scanType: "Register"
+                  verbosity: "Verbose"
+                  alertWarningLevel: "High"
+              - task: UseNode@1
+                displayName: Use Node 18.x
+                inputs:
+                  version: 18.x
+              - task: Npm@1
+                displayName: Install
+                inputs:
+                  command: "custom"
+                  customCommand: "ci"
+              - task: CmdLine@2
+                displayName: Build
+                inputs:
+                  script: "npm run build"
+              - task: CmdLine@2
+                displayName: Lint
+                inputs:
+                  script: "npm run lint"
+              - task: CmdLine@2
+                displayName: Test
+                inputs:
+                  script: "npm run ci:test"
+              - task: PublishTestResults@2
+                displayName: Publish Test Results
+                inputs:
+                  testResultsFormat: "JUnit"
+                  testResultsFiles: "**/*junit-report.xml"
+                  searchFolder: "$(System.DefaultWorkingDirectory)"
+                condition: succeededOrFailed()


### PR DESCRIPTION
This PR converts the FluidHelloWorld pipeline to the new 1ES template required by Microsoft. The pipeline essentially now extends a new template from Microsoft that enables security and auditing checks by Microsoft. Read more on how the logic for converting to a 1ES pipeline works on [the official 1ES wiki](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/onboarding/overview) 