### PR TITLE
Updated the Change event of the dice `treeChanged` -> `afterChange`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -92,7 +92,7 @@ const renderDiceRoller = (dice, elem) => {
 	updateDice();
 
 	// Use the changed event to trigger the rerender whenever the value changes.
-	Tree.on(dice, "treeChanged", updateDice);
+	Tree.on(dice, "afterChange", updateDice);
 	// Setting "fluidStarted" is just for our test automation
 	window.fluidStarted = true;
 };


### PR DESCRIPTION
`treeChanged` is giving below runtime errors. So, I changed this to `afterChange`, this fixed the issue.🙂
<br />
<img width="624" alt="Screenshot 2024-04-19 at 2 55 23 PM" src="https://github.com/microsoft/FluidHelloWorld/assets/78208876/ac4c433e-49cc-42e9-bd30-991654b9acce">

It's also mentioned in your <a href="https://fluidframework.com/docs/start/tutorial/#handling-remote-changes">documentation</a>
<br/>
<img width="1468" alt="Screenshot 2024-04-19 at 2 52 40 PM" src="https://github.com/microsoft/FluidHelloWorld/assets/78208876/eaf457a3-668b-44de-ba6e-50147552682d">
