### PR TITLE
Allow dependabot to update all dependencies and group FF PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-name: "fluid-framework"
-      - dependency-name: "@fluidframework/*"
+    groups:
+      fluid-framework-dependencies:
+        patterns:
+          - "@fluidframework"
+          - "fluid-framework"


### PR DESCRIPTION
I recently made a change in FluidExamples that seems to be working well, this would do the same for this repo:

https://github.com/microsoft/FluidExamples/pull/1048