### PR TITLE
Bump to FF 2.3 and fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     reviewers: 
       - "microsoft/team-json"
       - "microsoft/team-rohan"
-    # Look for `package.json` and `package-lock.json` files in these directories
-    directories:
-      - "/"
     schedule:
       interval: "daily"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
     reviewers:
-      - "microsoft/team-jason"
-      - "microsoft/team-rohan"
+      - "microsoft/fluid-cr-devx"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
     reviewers: 
-      - "microsoft/team-json"
+      - "microsoft/team-jason"
       - "microsoft/team-rohan"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     reviewers: 
       - "microsoft/team-jason"
       - "microsoft/team-rohan"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
     schedule:
       interval: "daily"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
-    reviewers: 
+    reviewers:
       - "microsoft/team-jason"
       - "microsoft/team-rohan"
     # Look for `package.json` and `lock` files in the `root` directory

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,16 @@ version: 2
 updates:
   # Enable version updates for npm
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/"
+    reviewers: 
+      - "microsoft/team-json"
+      - "microsoft/team-rohan"
+    # Look for `package.json` and `package-lock.json` files in these directories
+    directories:
+      - "/"
     schedule:
       interval: "daily"
     groups:
       fluid-framework-dependencies:
         patterns:
-          - "@fluidframework"
+          - "@fluidframework*"
           - "fluid-framework"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/tinylicious-client": "^2.2.0",
-				"fluid-framework": "^2.2.0"
+				"@fluidframework/tinylicious-client": "^2.3.0",
+				"fluid-framework": "^2.3.0"
 			},
 			"devDependencies": {
 				"@fluidframework/build-common": "^2.0.3",
@@ -624,12 +624,13 @@
 			}
 		},
 		"node_modules/@fluid-internal/client-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.2.0.tgz",
-			"integrity": "sha512-EfwSDsNMhWvVXRSaaU6m5i8aPBrupSvg0vPLlOmCyeXVfO0e4jERJoadkgP2uBMZFIgiKFVqP+E+35zrY5Ajqw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.3.0.tgz",
+			"integrity": "sha512-zKSk3bMkrPrhYyu4IY1E0GigsS5N7uCq6s+d2lU7Wif52YtyfglMqRH308d1LcZIoiqzDFaU7HTzuLMjOblDcQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
 				"@types/events_pkg": "npm:@types/events@^3.0.0",
 				"base64-js": "^1.5.1",
 				"buffer": "^6.0.3",
@@ -638,24 +639,25 @@
 			}
 		},
 		"node_modules/@fluidframework/aqueduct": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.2.0.tgz",
-			"integrity": "sha512-vc5bH0Q/0i13eyjSgkp+KHNG33QfMxg/ZDlrNVnI3gMX25TP2GCLP2DRK6U5WCR6QxCUCbIpQEPBVy2E9WiU3g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.3.0.tgz",
+			"integrity": "sha512-GeJgDelCjTS/X3gmkZSyIlGAdR5Z/CX7rzYVPxF4ij2xvJ4oI0reIribssKVvdacvdEBADO6SJF7mDqqjVMagw==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-runtime": "~2.2.0",
-				"@fluidframework/container-runtime-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/map": "~2.2.0",
-				"@fluidframework/request-handler": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/synthesize": "~2.2.0"
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-runtime": "~2.3.0",
+				"@fluidframework/container-runtime-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/map": "~2.3.0",
+				"@fluidframework/request-handler": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/synthesize": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/build-common": {
@@ -687,26 +689,28 @@
 			}
 		},
 		"node_modules/@fluidframework/container-definitions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.2.0.tgz",
-			"integrity": "sha512-UXqE6wRNgscd6QNGVbgYuPfGlnS6dbSDVEsBUQKc6g29nwcBDe2ynM1RuRl+xCwhYnJx5OiaXDIgDHtpyD2GcQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.3.0.tgz",
+			"integrity": "sha512-bmCi6aFZj+rP+hm/9UFfJ1ZiLJ100900iaSUp9IC6vzN2DhXHh0LSJyTXWzUwBBwyntblAMXpaGBqSqopXZzvQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0"
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/container-loader": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.2.0.tgz",
-			"integrity": "sha512-Kgp3THALf6FCyGOm0p0MaEHKOxJZ8bh+A7HXqAJz7Onhos8QSXPBZ1GyXFGqyv0haQ7gqLYB7GXk50KKx87W0Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.3.0.tgz",
+			"integrity": "sha512-MmVSaEbu6vPJlXpQwOAYQId/6p88jK5cLkWKm75KKZsSSoT+IjuJpJQv66TXM+rVgCmCZ1AXGYaMmD3uHK20PA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"@types/events_pkg": "npm:@types/events@^3.0.0",
 				"@ungap/structured-clone": "^1.2.0",
 				"debug": "^4.3.4",
@@ -716,22 +720,23 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.2.0.tgz",
-			"integrity": "sha512-7jSSxaSLFVVAlXvG6vIJ2bbTEZm71F8pHpNislFhBS9UT90XlUncTDvumTvq3MBEcbT2Pod/jmeQUz8CUVLp7g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.3.0.tgz",
+			"integrity": "sha512-UKbmVRd2A6JM162MENfX+BiIGByYM/QvlMybttvFjaPdF/4tPH0/dnGaWS1vVAt0ztesatVQLvBTnMzZjvBtFA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-runtime-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/id-compressor": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-runtime-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/id-compressor": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"double-ended-queue": "^2.1.0-0",
 				"lz4js": "^0.2.0",
@@ -739,112 +744,121 @@
 			}
 		},
 		"node_modules/@fluidframework/container-runtime-definitions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.2.0.tgz",
-			"integrity": "sha512-ImOT6hr1PWBV2ADlHXFEB1f2MsiguOoIs2py02y3K8hv+EZnw6yUO2K2OOMd/abK2r43PCSRNRnM1Z3C/VyMxg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.3.0.tgz",
+			"integrity": "sha512-nSuCZFS6PeC8KZzfOFt2vTedMG2xTYKyFVCSnGBMuU/d2NMuqUg/1vchWR/HdO7F69yfngFPgaE5ebpvP3kAug==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0"
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/core-interfaces": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.2.0.tgz",
-			"integrity": "sha512-Ja9NrOJvTW9vxkXEapqBQfSjIDiowOrBE+++y34CsnCQlXIj8fxKqsf/WcrILhnXoxD4kSXqkz/tQhR30iUyjw=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.3.0.tgz",
+			"integrity": "sha512-gD5gRlAaKzlhwRsHqTPbcsfIJbq4p9rxxljTOlkdQyaSn/oHwtffi7YOHYX40hSdLHxkqqwscyx/um0KXaZWyA==",
+			"license": "MIT"
 		},
 		"node_modules/@fluidframework/core-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.2.0.tgz",
-			"integrity": "sha512-UT+WRm8TPebpZ8pjn0V4U+9Y5in01NIPNc5MtHJYpmPkLLa9+hVnyMOX8VbnZ9zShdhyzn9uYGc3ti4a2tzDMg=="
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.3.0.tgz",
+			"integrity": "sha512-crEiFLj515dtIvZnPjQ9H+/2O24bAzZNfebTATwBBHZwpb9C3bZo5qeykP6ZChAtofRCWRQqAcoLQVeqQZdVOg==",
+			"license": "MIT"
 		},
 		"node_modules/@fluidframework/datastore": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.2.0.tgz",
-			"integrity": "sha512-qeDVNUn+SM0geeJbuECYx5rkHPFUk0XU9ZolLK3pmYGzUTJ5vEhNAXeXkGC3CVR/h9BTAKW4DtCorpz8BqVvTw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.3.0.tgz",
+			"integrity": "sha512-xXHRGe02epbXl8TBbyaZ+vr6ylrr+59ZDvWcfoUoe13imlOS+uSdMoFmqT1fvyf+P34q8NBBawswMgkhAuRN+g==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/id-compressor": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/id-compressor": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/datastore-definitions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.2.0.tgz",
-			"integrity": "sha512-MuUUkiM+gMiBFpV+Uvd4snqu/rGds5o/dpqN46utnuxbcMomUDtgb1m8B1M/OadHHXOBs9mbAjWRkbjlf3tfFg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.3.0.tgz",
+			"integrity": "sha512-Nfc1ENDacPwSTCkr6XgvCvK3WnWFBX/4OLpNKn5yZ/7fG65f4yCl148a5wSj5oy/mf+/XtXceZBJ34IukW5iQw==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/id-compressor": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0"
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/id-compressor": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.2.0.tgz",
-			"integrity": "sha512-kk1uhOK613Yzp76D8HriLD4xumZ1MY3Tj4wMMwiv+b/URhw7x5mTWG55t1AUC+JTNqttNNmc8PmGB46Fxf0fiA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.3.0.tgz",
+			"integrity": "sha512-7eGXON6FvHMyd77BSKMmIZ/I19UDaxqslgD523eDDYoKM3+1nUPm1QqRCtsLuq416nqVQrSiPPXDh7fII9Bl6w==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0"
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-definitions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.2.0.tgz",
-			"integrity": "sha512-r0jRut/MqNPii5CLZ6ShtGfGy1RpQ8163KzTOw1Af2wLCoEOKnZaSvDb23/UDMUEaM0Pv663d1K0jmOgltKf2g==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.3.0.tgz",
+			"integrity": "sha512-uLIhiFyu+OQ79HL7xcDB8f2nxa2sYFLCWFF6JT8T1jMC8N0fLRB56SQFg4LZRZDRjbcwkoRN8rQckFyzcu97Gg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/core-interfaces": "~2.2.0"
+				"@fluidframework/core-interfaces": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/driver-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.2.0.tgz",
-			"integrity": "sha512-xf/3ytaRNRlSVgmAusFVECntF9q02Z+H8qrRk6mlr7mzt+VaR8oDavRoOrn0pzqer9v40qzk3N3tBD9F8qM90A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.3.0.tgz",
+			"integrity": "sha512-sxZAX/Fk+JYRW/W3tI87CLqhOl2w2zaqyoeM0v83dM0sD1CGdXwey3AWulomj+i7/wNv93K3kGd6aH5xBIBKSQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
-				"axios": "^1.6.2",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
+				"axios": "^1.7.7",
 				"lz4js": "^0.2.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/fluid-static": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.2.0.tgz",
-			"integrity": "sha512-BvQzYV/ZG2s0K0LDFwY+4WRVxZ/fmbRfvS0+ZD3L7AgOq9j1t/aMssdjBJne3YiO5ct79JQTecv9VeWUCv7QBg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.3.0.tgz",
+			"integrity": "sha512-rh5EzkyRa83I8Pixz/bpdO0Xf7MMzlItX6q10YdvxRnCHV8mq6djSOAv+ZE0gYF+w601zALy/Q3Z+Y4dhMbydA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/aqueduct": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-loader": "~2.2.0",
-				"@fluidframework/container-runtime": "~2.2.0",
-				"@fluidframework/container-runtime-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/request-handler": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0"
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/aqueduct": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-loader": "~2.3.0",
+				"@fluidframework/container-runtime": "~2.3.0",
+				"@fluidframework/container-runtime-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/request-handler": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/gitresources": {
@@ -853,52 +867,55 @@
 			"integrity": "sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA=="
 		},
 		"node_modules/@fluidframework/id-compressor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.2.0.tgz",
-			"integrity": "sha512-T6Y6OPTqKumlsNihlGWaPoMCfdAxRC/I2soGZIvYSCOYiULfGPNo+F/ZEVRUeG0zD80ZA47U1ee/fTpNWIBFjQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.3.0.tgz",
+			"integrity": "sha512-YtcpdEtQ2Lp93/iJxaZpg4r1b/eLCcIxc9VajGt279GUVkhQ7JPPzSguLESzuGAIsNYqFm3OlcQU9iTUyb6L7w==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/map": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.2.0.tgz",
-			"integrity": "sha512-WhNI3qb5aY4f33Vy4lpooUlzdMpUY2L0dLHIbfLyfZVqX4ZyS8tWBaRIc6gekwyCCC6dn+CikOct8yZ+zuJ78A==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.3.0.tgz",
+			"integrity": "sha512-gGAB0BcZ7WHmfalQ5ZUF/1REQFD/uDe9crrAZu6XERq15UQtAS2mn6Mw1YgDhSAw4H9i7zn35ljfdbhi/YVmbg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/merge-tree": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/merge-tree": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"path-browserify": "^1.0.1"
 			}
 		},
 		"node_modules/@fluidframework/merge-tree": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.2.0.tgz",
-			"integrity": "sha512-cWilAM4sCnVicnOCpk1P8zj3CVDfocv2Exkx4AbNZqmOpvwdL4jMXpqO/KSAzMoH/Gv9eUu8OgcNQIXRyBchIQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.3.0.tgz",
+			"integrity": "sha512-M1/djCM0skVtVjVwq8I8G9fWaNTbESExnW+Kc2IUnkiYtb+QtkWe4aSPNIB7DM4Ed8Bz442RVJSeCIBQJPOK5A==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0"
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/protocol-base": {
@@ -918,30 +935,32 @@
 			"integrity": "sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA=="
 		},
 		"node_modules/@fluidframework/request-handler": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.2.0.tgz",
-			"integrity": "sha512-urldbVteWlLUHFNsqQk2qQQD53FtCgLqgX6m7KIhMfoSAY/2U45QPPT2gvyS04T1rE+3IK4i6OORd8tBm1BRzQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.3.0.tgz",
+			"integrity": "sha512-U6Ck1IrARRZIk6zI9h1+3twzWM42YU0Ajm6VwjgEEKPMrT5TFQ5+AGwx4KOKQ9KaC84M3utHcT/RyOCUDjwTtg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-runtime-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0"
+				"@fluidframework/container-runtime-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/routerlicious-driver": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.2.0.tgz",
-			"integrity": "sha512-HMLby/MpWsehTf7tbKNx+qrDP1B1v1OchiNCMojXpj/eqFFdByMdKbv/xHfiwDtg/JdibD9W4UG/aRUnluFvYw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.3.0.tgz",
+			"integrity": "sha512-Jwb6eNJefr2pogeq3bwXVjcaDY0TmU8iyk5Vu1IPRHjWJJknmrFcSVgziA4dtP0fvNqbawuw7eZsJGCv4Eqhbg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-base": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-base": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
 				"@fluidframework/server-services-client": "^5.0.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"cross-fetch": "^3.1.5",
 				"json-stringify-safe": "5.0.1",
 				"socket.io-client": "^4.7.3",
@@ -949,49 +968,52 @@
 			}
 		},
 		"node_modules/@fluidframework/runtime-definitions": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.2.0.tgz",
-			"integrity": "sha512-NH89DRen66GmRmhjWiuf0t71yEAtvj6Y54XWViMeHeU5uMP1EyozWECzZfNWeUrrXr68/pRQFas+Og42gY9Wpg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.3.0.tgz",
+			"integrity": "sha512-v/577GKi9M7hlfW3bFXHua1LO+0taa7tkEUoHDJgDrpDOjFczXjbIGUWNrPQiHbx+3HQAnWh74zhO4GbVzlfeA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/id-compressor": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0"
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/id-compressor": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/runtime-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.2.0.tgz",
-			"integrity": "sha512-7A8DHKKZV8phBq9onTnnIgiPWTZgSk5gknOPx6lzTRzq/zAbWjaKoAtQowcN1ygteY9ixtNR0nALdrsUt40Otg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.3.0.tgz",
+			"integrity": "sha512-8sZtzZRP2HORTbsERFcqKSuRJ1Fd64CO44wfyqMtLDwxFMaThk1r6mG3eQR5ClFz5f7Jt55ceTzIyrF+3Q1Tow==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-runtime-definitions": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0"
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-runtime-definitions": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/sequence": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.2.0.tgz",
-			"integrity": "sha512-kO4O9nDjYAty5LLKZOS3vmEuPber3alrPJWAgR0o2h1SZnhE9u+rSdytOEgD6DxzwHjDwi/hKgE5M/apaFQwxg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.3.0.tgz",
+			"integrity": "sha512-wbSApa/tUEoAXTyeoP7cHjUVahC2HIT2nKlQZaeWCrrzbYUiT6wgMSSdwKU6lso+1foelFzcID49UQE52at+Jg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/merge-tree": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/merge-tree": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"double-ended-queue": "^2.1.0-0",
 				"uuid": "^9.0.0"
 			}
@@ -1298,93 +1320,99 @@
 			}
 		},
 		"node_modules/@fluidframework/shared-object-base": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.2.0.tgz",
-			"integrity": "sha512-hyyY+Hpi3lYXDasJUK38nDWMaE3kDiym7JnxzUsSoUEQbOH+t9ubxP8TOfZLNTxIG8rQUoAko9qVJHompGgRog==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.3.0.tgz",
+			"integrity": "sha512-cWImlu5L6s346/mQTwUV7ZZVPhRWmyGCPGPM75+/NMl1DyKsd402haMl16vXPQRlPIOWkqTTDZE3/gtNVshmXQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-runtime": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-runtime": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/synthesize": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.2.0.tgz",
-			"integrity": "sha512-gcI/Sqbe24/ktC44tjrQ62Dwe2yNKLfkAzJKJURFpEPPeBR0i4DPM2z3LKYjpZtxqgwfIEDqAT7z88byxjpUig==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.3.0.tgz",
+			"integrity": "sha512-yjMlci9PMp+B47/DZHWBqsg4Q5b5xnZOl/g0PX85JwlXU7zKa2fqrFk096YvPotZh0mmB9EFRNewTYfOeGayDA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/core-utils": "~2.2.0"
+				"@fluidframework/core-utils": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/telemetry-utils": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.2.0.tgz",
-			"integrity": "sha512-KRDDgYCqiabZ7KFo/vcgzVf09rWU6ExQza50zfBjB+GrDL/lL7/tyrY/3P4sY4Nw+iC/QcLblNX3ugDF2NtwLw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.3.0.tgz",
+			"integrity": "sha512-U+go4eR9ALoeJ/5r9UkTgFxsR9OXWCA3PxocbqcevcEgoi8WanF2DtlRH1wa5af6j1qTXsmNRhY67m/5ARPMYA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
 				"debug": "^4.3.4",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-client": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.2.0.tgz",
-			"integrity": "sha512-M5oiGzmlV1xRXcgdjwxC3hVcRmEVw7RNIl3nxnbYVordKTTesb48chgibEeLtMTcOQ44P7SDUYRRpAc6Ed5c2w==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-client/-/tinylicious-client-2.3.0.tgz",
+			"integrity": "sha512-w4XSWvA0l7H8fp2NZaBqZJsLSV7rCV4SVWw4aj0s5z7x6mMBV2ZgGJ8mQEC4zglLtpBDjq8VejE4WonTbhmtvA==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-loader": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/fluid-static": "~2.2.0",
-				"@fluidframework/map": "~2.2.0",
-				"@fluidframework/routerlicious-driver": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
-				"@fluidframework/tinylicious-driver": "~2.2.0"
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-loader": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/fluid-static": "~2.3.0",
+				"@fluidframework/map": "~2.3.0",
+				"@fluidframework/routerlicious-driver": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
+				"@fluidframework/tinylicious-driver": "~2.3.0"
 			}
 		},
 		"node_modules/@fluidframework/tinylicious-driver": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.2.0.tgz",
-			"integrity": "sha512-r69EPbL/nY/g9BGTd3i+b5xGux0K3kZqwPPiqQ+W3mSVfirTz9oHjFkUw5qgVdpYNpD8Uk5a3j3ALKT6KAk+Ww==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-2.3.0.tgz",
+			"integrity": "sha512-RHmpeM7RWpmE/eZvHgg10GYiTSclCMQqUQ62ia9LHC4SZy6dQpE8gMFSdpqQDqdvtjDGUC2b1Ey9NSIRbzmI6w==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/driver-utils": "~2.2.0",
-				"@fluidframework/routerlicious-driver": "~2.2.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/driver-utils": "~2.3.0",
+				"@fluidframework/routerlicious-driver": "~2.3.0",
 				"jsrsasign": "^11.0.0",
 				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@fluidframework/tree": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.2.0.tgz",
-			"integrity": "sha512-QDe9nxhP7ylYyL12prOkgEoFR4ipcAHaHyLBkPtv/P+YhfXqb1RsxR/9vrA8BlkEYzbXK88QWaODw2Ow5lsp+Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.3.0.tgz",
+			"integrity": "sha512-VBHan0/QuoJPhoCU9R3Drj/czhdpxmWt5G7qFyQjYt2bjcCsxSuNq/QmG3F3k9bxKM/q1KLzqq+fWWp+tVGXcg==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluid-internal/client-utils": "~2.2.0",
-				"@fluidframework/container-runtime": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/core-utils": "~2.2.0",
-				"@fluidframework/datastore-definitions": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/id-compressor": "~2.2.0",
-				"@fluidframework/runtime-definitions": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/telemetry-utils": "~2.2.0",
+				"@fluid-internal/client-utils": "~2.3.0",
+				"@fluidframework/container-runtime": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/core-utils": "~2.3.0",
+				"@fluidframework/datastore-definitions": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/id-compressor": "~2.3.0",
+				"@fluidframework/runtime-definitions": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/telemetry-utils": "~2.3.0",
 				"@sinclair/typebox": "^0.32.29",
 				"@tylerbu/sorted-btree-es6": "^1.8.0",
 				"@ungap/structured-clone": "^1.2.0",
@@ -1903,7 +1931,8 @@
 		"node_modules/@sinclair/typebox": {
 			"version": "0.32.35",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.32.35.tgz",
-			"integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA=="
+			"integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
+			"license": "MIT"
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
@@ -1966,7 +1995,8 @@
 		"node_modules/@tylerbu/sorted-btree-es6": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/@tylerbu/sorted-btree-es6/-/sorted-btree-es6-1.8.0.tgz",
-			"integrity": "sha512-qkwgE0G5OGn7F+1fMkFZLwyjc99xCy4kmQ8p7N0Jj540HD6xU0jTPjcqELogH4f5YGMPXLqd8sQ7uOYC0QRBeg=="
+			"integrity": "sha512-qkwgE0G5OGn7F+1fMkFZLwyjc99xCy4kmQ8p7N0Jj540HD6xU0jTPjcqELogH4f5YGMPXLqd8sQ7uOYC0QRBeg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -2092,7 +2122,8 @@
 			"name": "@types/events",
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+			"license": "MIT"
 		},
 		"node_modules/@types/express": {
 			"version": "4.17.21",
@@ -2342,7 +2373,8 @@
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"license": "ISC"
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.12.1",
@@ -3906,6 +3938,7 @@
 			"version": "3.1.8",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
 			"integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+			"license": "MIT",
 			"dependencies": {
 				"node-fetch": "^2.6.12"
 			}
@@ -4387,21 +4420,23 @@
 			}
 		},
 		"node_modules/engine.io-client": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
-			"integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
+			"integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+			"license": "MIT",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.1",
 				"engine.io-parser": "~5.2.1",
 				"ws": "~8.17.1",
-				"xmlhttprequest-ssl": "~2.0.0"
+				"xmlhttprequest-ssl": "~2.1.1"
 			}
 		},
 		"node_modules/engine.io-client/node_modules/ws": {
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
 			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -5111,20 +5146,21 @@
 			}
 		},
 		"node_modules/fluid-framework": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.2.0.tgz",
-			"integrity": "sha512-5VEiEC0KuCJaph2ud1+U1pKNcbm896PgbQGqD/9PTK5W8GfGD+BeXqpeD2tyZrJfblLqkCLCrZLPTHXciUE4Kg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.3.0.tgz",
+			"integrity": "sha512-FeZSowL/BVy18DqOVx9GjQphfxBy8p9hRHVm/LSX56IIZ0s21ZDvwGAJ39csLbqVsf6tyUie+jEefdylikatyw==",
+			"license": "MIT",
 			"dependencies": {
-				"@fluidframework/container-definitions": "~2.2.0",
-				"@fluidframework/container-loader": "~2.2.0",
-				"@fluidframework/core-interfaces": "~2.2.0",
-				"@fluidframework/driver-definitions": "~2.2.0",
-				"@fluidframework/fluid-static": "~2.2.0",
-				"@fluidframework/map": "~2.2.0",
-				"@fluidframework/runtime-utils": "~2.2.0",
-				"@fluidframework/sequence": "~2.2.0",
-				"@fluidframework/shared-object-base": "~2.2.0",
-				"@fluidframework/tree": "~2.2.0"
+				"@fluidframework/container-definitions": "~2.3.0",
+				"@fluidframework/container-loader": "~2.3.0",
+				"@fluidframework/core-interfaces": "~2.3.0",
+				"@fluidframework/driver-definitions": "~2.3.0",
+				"@fluidframework/fluid-static": "~2.3.0",
+				"@fluidframework/map": "~2.3.0",
+				"@fluidframework/runtime-utils": "~2.3.0",
+				"@fluidframework/sequence": "~2.3.0",
+				"@fluidframework/shared-object-base": "~2.3.0",
+				"@fluidframework/tree": "~2.3.0"
 			}
 		},
 		"node_modules/fn.name": {
@@ -7548,7 +7584,8 @@
 		"node_modules/lz4js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
-			"integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg=="
+			"integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+			"license": "ISC"
 		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
@@ -7945,6 +7982,7 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -9633,13 +9671,14 @@
 			}
 		},
 		"node_modules/socket.io-client": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
-			"integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
+			"integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+			"license": "MIT",
 			"dependencies": {
 				"@socket.io/component-emitter": "~3.1.0",
 				"debug": "~4.3.2",
-				"engine.io-client": "~6.5.2",
+				"engine.io-client": "~6.6.1",
 				"socket.io-parser": "~4.2.4"
 			},
 			"engines": {
@@ -10318,7 +10357,8 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
 		},
 		"node_modules/tree-dump": {
 			"version": "1.0.2",
@@ -10655,7 +10695,8 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/webpack": {
 			"version": "5.94.0",
@@ -11017,6 +11058,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -11162,9 +11204,9 @@
 			"dev": true
 		},
 		"node_modules/xmlhttprequest-ssl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-			"integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
+			"integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
 			"engines": {
 				"node": ">=0.4.0"
 			}

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		"test:jest": "jest"
 	},
 	"dependencies": {
-		"@fluidframework/tinylicious-client": "^2.2.0",
-		"fluid-framework": "^2.2.0"
+		"@fluidframework/tinylicious-client": "^2.3.0",
+		"fluid-framework": "^2.3.0"
 	},
 	"devDependencies": {
 		"@fluidframework/build-common": "^2.0.3",


### PR DESCRIPTION
This PR bumps to FF latest release 2.3.0 and also, updates the dependabot config to add reviewers and `*` to group `@fluidframework` updates: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-3

dependabot correctly opens PR for fluid-framework deps: https://github.com/microsoft/FluidHelloWorld/pull/411