### PR TITLE
Disable ARROW

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: v1/M365.Unfficial.PipelineTemplate.yml@m365Pipelines
+  template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
       name: Small-1ES

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,13 +21,6 @@ extends:
       name: Small-1ES
       os: linux
     sdl:
-      # arrow:
-      #   # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-      #   # Currently we want to use different names for internal and public builds for Arrow Service Connection
-      #   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      #     serviceConnection: ff-internal-arrow-sc
-      #   ${{ else }}:
-      #     serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,19 +15,19 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: v1/M365.Official.PipelineTemplate.yml@m365Pipelines
+  template: v1/M365.Unfficial.PipelineTemplate.yml@m365Pipelines
   parameters:
     pool:
       name: Small-1ES
       os: linux
     sdl:
-      arrow:
-        # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
-        # Currently we want to use different names for internal and public builds for Arrow Service Connection
-        ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-          serviceConnection: ff-internal-arrow-sc
-        ${{ else }}:
-          serviceConnection: ff-public-arrow-sc
+      # arrow:
+      #   # This is the service connection for the Arrow Service Connection in FluidFramework Azure DevOps organization
+      #   # Currently we want to use different names for internal and public builds for Arrow Service Connection
+      #   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+      #     serviceConnection: ff-internal-arrow-sc
+      #   ${{ else }}:
+      #     serviceConnection: ff-public-arrow-sc
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-2022


### PR DESCRIPTION
This repository only contains sample code, not intended to be deployed as-is, and thus should be classified as a non-production repo/code. As such, it can use the Unofficial 1ES pipeline template and doesn't need to enable ARROW.