### PR TITLE
Make package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "@fluid-example/hello-world",
 	"version": "0.1.0",
+	"private": true,
 	"description": "Minimal Fluid Container & Data Object sample to implement a collaborative dice roller as a standalone app.",
 	"repository": "microsoft/FluidHelloWorld",
 	"license": "MIT",


### PR DESCRIPTION
Adds `private: true` to package.json to further indicate that this package is sample code, not intended to be published or deployed anywhere.