### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners are automatically requested as reviewers for any changes to package.json or package-lock.json files in the repository.
+# PRs that modify these files will request review from @microsoft/fluid-cr-devx.
+/package.json @microsoft/fluid-cr-devx
+/package-lock.json @microsoft/fluid-cr-devx

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,6 @@ version: 2
 updates:
   # Daily updates for Fluid Framework dependencies
   - package-ecosystem: "npm"
-    reviewers:
-      - "microsoft/fluid-cr-devx"
     # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
     schedule:
@@ -24,8 +22,6 @@ updates:
 
   # Weekly updates for non-Fluid dependencies
   - package-ecosystem: "npm"
-    reviewers:
-      - "microsoft/fluid-cr-devx"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The reviewers option has been removed from dependabot’s configuration, as noted in this post: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.

I wasn’t able to configure reviewers specifically for dependabot PRs. Instead, I added a CODEOWNERS file that assigns @microsoft/fluid-cr-devx as reviewers for any PR that modifies package.json or package-lock.json.