### PR TITLE
feat: updated pipeline settings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,6 @@ extends:
     # Skip tagging if Github PR coming from a fork
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Permissive,Npm
     customBuildTags:
       - ES365AIMigrationTooling
     stages:
@@ -49,6 +48,11 @@ extends:
                 displayName: Use Node 22.x
                 inputs:
                   version: 22.x
+              - task: CmdLine@2
+                displayName: Configure npm registry
+                script: |
+                  echo "registry=https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/" > .npmrc
+                  echo "replace-registry-host=always" >> .npmrc
               - task: Npm@1
                 displayName: Install
                 inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,9 +50,10 @@ extends:
                   version: 22.x
               - task: CmdLine@2
                 displayName: Configure npm registry
-                script: |
-                  echo "registry=https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/" > .npmrc
-                  echo "replace-registry-host=always" >> .npmrc
+                inputs:
+                  script: |
+                    echo "registry=https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/" > .npmrc
+                    echo "replace-registry-host=always" >> .npmrc
               - task: Npm@1
                 displayName: Install
                 inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ extends:
     # Skip tagging if Github PR coming from a fork
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive,Npm
     customBuildTags:
       - ES365AIMigrationTooling
     stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ resources:
       name: 1ESPipelineTemplates/M365GPT
       ref: refs/tags/release
 
+variables:
+  - group: ado-feeds
 extends:
   template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:
@@ -52,7 +54,7 @@ extends:
                 displayName: Configure npm registry
                 inputs:
                   script: |
-                    echo "registry=https://pkgs.dev.azure.com/fluidframework/public/_packaging/publicPackages/npm/registry/" > .npmrc
+                    echo "registry=$(ado-feeds-primary-registry)" > .npmrc
                     echo "replace-registry-host=always" >> .npmrc
               - task: Npm@1
                 displayName: Install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ resources:
 
 variables:
   - group: ado-feeds
+  
 extends:
   template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ resources:
 
 variables:
   - group: ado-feeds
-  
+
 extends:
   template: v1/M365.Unofficial.PipelineTemplate.yml@m365Pipelines
   parameters:


### PR DESCRIPTION
The pipeline seems to be failing to install certain packages because a new policy was added to the `Start Network Isolation` step of the pipeline, (CFSClean), which doesn't allow public npm packages to be installed. This change should fix the issue.