### PR TITLE
fix(ci): use Puppeteer's bundled browser

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,6 @@ extends:
                 inputs:
                   command: "custom"
                   customCommand: "ci"
-                env:
-                  PUPPETEER_SKIP_DOWNLOAD: "true"
               - task: CmdLine@2
                 displayName: Build
                 inputs:

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -3,34 +3,6 @@
  * Licensed under the MIT License.
  */
 
-const { existsSync } = require("node:fs");
-
-const resolveExecutablePath = () => {
-	if (process.env.PUPPETEER_EXECUTABLE_PATH !== undefined) {
-		return process.env.PUPPETEER_EXECUTABLE_PATH;
-	}
-
-	const candidatesByPlatform = {
-		darwin: ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
-		linux: ["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"],
-		win32: [
-			"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-			"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
-		],
-	};
-	const candidates = candidatesByPlatform[process.platform] ?? [];
-	const executablePath = candidates.find((path) => existsSync(path));
-	if (executablePath !== undefined) {
-		return executablePath;
-	}
-
-	if (process.env.PUPPETEER_SKIP_DOWNLOAD === "true") {
-		throw new Error(
-			"No Chrome executable found. Set PUPPETEER_EXECUTABLE_PATH to a valid browser path.",
-		);
-	}
-};
-
 module.exports = {
 	server: {
 		command: `npm run start:client -- --port=7575`,
@@ -40,7 +12,6 @@ module.exports = {
 	launch: {
 		slowMo: 30, // slows down process for easier viewing
 		headless: "new", // run in the browser; https://developer.chrome.com/articles/new-headless/
-		executablePath: resolveExecutablePath(),
 		args: ["--no-sandbox", "--disable-setuid-sandbox"], // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
 		dumpio: process.env.FLUID_TEST_VERBOSE !== undefined, // output browser console to cmd line
 	},


### PR DESCRIPTION
## Description

Restore Puppeteer's browser download and remove the custom system Chrome resolution added in #620.

The system Chrome on the Linux CI pool can fail to expose its DevTools WebSocket before Puppeteer's launch timeout, as seen in [build 413683](https://dev.azure.com/fluidframework/public/_build/results?buildId=413683). Using Puppeteer's version-matched Chrome avoids depending on the pool's browser installation while retaining the Jest 30 compatibility environment shim.

## Validation

- npm run ci:test
- npm run lint