### PR TITLE
Configure 7-day cooldown for external dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       jest:
         patterns:


### PR DESCRIPTION
Configure Dependabot with a 7-day cooldown for the weekly external dependency update check. This aligns Dependabot PR creation with the repository's 7-day quarantine period for external dependencies and avoids update conflicts during that window.

The daily Fluid Framework dependency check remains unchanged so those updates can continue to arrive promptly.